### PR TITLE
Reduce crate size by adding a 'include' directive to manifest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["diff", "ast", "difftool"]
 categories = ["command-line-utilities"]
 build = "build.rs"
 homepage = "https://github.com/afnanenayet/diffsitter"
+include = ["src/**/*", "LICENSE", "README.md", "grammars/*", "build.rs", "!**/*.png", "!**/test/**/*", "!**/*_test.*", "!**/examples/**/*", "!**/target/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Please let me know if anything else should be included.


<details>

Here is the out put of `cargo diet`:

```
➜  diffsitter git:(master) cargo diet -r
┌───────────────────────────────────────────────────────────────────────────────────┬─────────────┐
│ Removed File                                                                      │ Size (Byte) │
├───────────────────────────────────────────────────────────────────────────────────┼─────────────┤
│ grammars/tree-sitter-ocaml/examples/.gitkeep                                      │           0 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/exis+ │           0 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suit+ │           0 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │           0 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/tmp/.gitignore │           3 │
│ .gitignore                                                                        │           8 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/liquidprompt/.gitignore         │          14 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/dos/dos.theme.bash              │          14 │
│ grammars/tree-sitter-python/examples/simple-statements-without-trailing-newline.+ │          16 │
│ grammars/tree-sitter-java/script/run-javaparser/target/maven-status/maven-compil+ │          20 │
│ test_data/test_a.py                                                               │          21 │
│ grammars/tree-sitter-bash/examples/bash-it/.ackrc                                 │          22 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          24 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suit+ │          25 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/ng.completion.ba+ │          28 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suit+ │          34 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          34 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          35 │
│ grammars/tree-sitter-bash/examples/bash-it/.gitattributes                         │          36 │
│ grammars/tree-sitter-python/examples/compound-statement-without-trailing-newline+ │          38 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/.gitattributes      │          41 │
│ grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/plugins/availab+ │          42 │
│ grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/aliases/availab+ │          42 │
│ grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/aliases/availab+ │          42 │
│ test_data/test_1_a.rs                                                             │          45 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          46 │
│ grammars/tree-sitter-python/examples/crlf-line-endings.py                         │          51 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          51 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          54 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/load.bash         │          56 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/pew.completion.b+ │          56 │
│ grammars/tree-sitter-python/examples/trailing-whitespace.py                       │          58 │
│ test_data/test_1_b.rs                                                             │          58 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/awless.completio+ │          63 │
│ grammars/tree-sitter-bash/examples/bash-it/.travis.yml                            │          63 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/edit-mode-vi.plugin+ │          67 │
│ test_data/test_b.py                                                               │          69 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/package.json     │          70 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │          70 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          70 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          70 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          70 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/jungle.completio+ │          71 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          72 │
│ grammars/tree-sitter-python/examples/multiple-newlines.py                         │          73 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suit+ │          73 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/edit-mode-emacs.plu+ │          73 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/export.completio+ │          73 │
│ grammars/tree-sitter-python/examples/mixed-spaces-tabs.py                         │          74 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/openshift.comple+ │          75 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/kontena.completi+ │          76 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/awscli.completio+ │          78 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          79 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          80 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/pipenv.completio+ │          82 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          85 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          93 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │          94 │
│ grammars/tree-sitter-c/test/highlight/keywords.c                                  │          95 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/fuck.aliases.bash    │          96 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/test_helpe+ │          97 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/ansible.aliases.bash │         100 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         102 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         106 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/load.bash           │         108 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         109 │
│ grammars/tree-sitter-java/script/run-javaparser/target/maven-status/maven-compil+ │         116 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         118 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/hub.plugin.bash      │         118 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/Makefile        │         123 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/.travis.yml         │         126 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/tmux.aliases.bash    │         126 │
│ grammars/tree-sitter-java/script/run-javaparser/target/maven-archiver/pom.proper+ │         128 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/hg.aliases.bash      │         128 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/chruby.plugin.bash   │         135 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         138 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/pipsi.plugin.bash    │         138 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/kubectl.completi+ │         138 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/.travis.yml      │         142 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/direnv.plugin.bash   │         143 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         144 │
│ grammars/tree-sitter-php/test/highlight/types.php                                 │         145 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/gh.plugin.bash       │         145 │
│ grammars/tree-sitter-bash/examples/bash-it/custom/example.bash                    │         149 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         150 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/gitsvn.aliases.bash  │         153 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/nvm.completion.b+ │         157 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/atom.aliases.bash    │         159 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/script/install-+ │         161 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/script/install-bat+ │         161 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/script/install-b+ │         161 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/load.bash        │         165 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/tmuxinator.plugin.b+ │         165 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/todo.txt-cli.aliase+ │         166 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/npm.completion.b+ │         167 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/package.json        │         173 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/chruby-auto.plugin.+ │         174 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/rvm.completion.b+ │         174 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/package.json      │         175 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/tmux.plugin.bash     │         175 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/textmate.plugin.bash │         175 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/docker-compose.alia+ │         175 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/makefile.complet+ │         177 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         179 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/conda.completion+ │         182 │
│ grammars/tree-sitter-bash/examples/update-authors.sh                              │         183 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         189 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/bundler.aliases.bash │         189 │
│ grammars/tree-sitter-ruby/test/corpus/single-cr-as-whitespace.rb                  │         197 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         199 │
│ grammars/tree-sitter-bash/examples/bash-it/test/lib/composure.bats                │         199 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/node.plugin.bash     │         199 │
│ grammars/tree-sitter-php/test/highlight/literals.php                              │         215 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/.travis.yml         │         222 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/.travis.yml       │         222 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         223 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/latex.plugin.bash    │         226 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/test_helper+ │         232 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/textmate.aliases.ba+ │         232 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         233 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         239 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/travis.completio+ │         239 │
│ grammars/tree-sitter-bash/examples/bash-it/.editorconfig                          │         240 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         242 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         243 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         247 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/README.md       │         253 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/git-subrepo.plugin.+ │         254 │
│ grammars/tree-sitter-bash/examples/bash-it/.gitignore                             │         254 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/history.plugin.bash  │         259 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/pip.completion.b+ │         262 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/pip3.completion.+ │         263 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/jenv.plugin.bash     │         268 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/rbenv.plugin.bash    │         270 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/sdkman.plugin.bash   │         273 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         278 │
│ grammars/tree-sitter-go/examples/no_newline_at_eof.go                             │         280 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         284 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp+ │         287 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/minimal/minimal.theme.bash      │         288 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/todo.plugin.bash     │         293 │
│ grammars/tree-sitter-c/test/corpus/crlf.txt                                       │         294 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/go.plugin.bash       │         297 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/test_helper.b+ │         301 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/svn.aliases.bash     │         304 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/package.json        │         305 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/java.plugin.bash     │         311 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/emacs.aliases.bash   │         313 │
│ grammars/tree-sitter-ruby/test/highlight/variables.rb                             │         319 │
│ grammars/tree-sitter-java/test/corpus/comments.txt                                │         320 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/maven.aliases.bash   │         321 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats+ │         331 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/candy/candy.theme.bash          │         333 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/brew.completion.+ │         336 │
│ grammars/tree-sitter-cpp/test/highlight/names.cpp                                 │         347 │
│ grammars/tree-sitter-ruby/test/corpus/line-endings.txt                            │         351 │
│ grammars/tree-sitter-python/test/highlight/keywords.py                            │         352 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/systemd.aliases.bash │         354 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/vault.aliases.bash   │         357 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/51-error-1+ │         362 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/homebrew-cask.alias+ │         363 │
│ grammars/tree-sitter-bash/examples/bash-it/lib/preview.bash                       │         367 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/primer/primer.theme.bash        │         370 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/tonotdo/tonotdo.theme.bash      │         378 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │         381 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │         383 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/visual-studio-code.+ │         384 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/doubletime_multiline_pyonly/do+ │         392 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/boot2docker.plugin.+ │         395 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/homebrew.aliases.ba+ │         396 │
│ grammars/tree-sitter-ruby/test/highlight/classes.rb                               │         398 │
│ grammars/tree-sitter-cpp/test/highlight/keywords.cpp                              │         401 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │         402 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-naked/powerline-nake+ │         409 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/doubletime_multiline/doubletim+ │         414 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/subversion.plugin.b+ │         423 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/dirs.completion.+ │         426 │
│ grammars/tree-sitter-ruby/test/highlight/constants.rb                             │         430 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/plenv.plugin.bash    │         432 │
│ grammars/tree-sitter-bash/examples/bash-it/.gitmodules                            │         433 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/ag.aliases.bash      │         440 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/ssh.plugin.bash      │         456 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/clipboard.aliases.b+ │         456 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/pyenv.plugin.bash    │         467 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │         470 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/docker-machine.plug+ │         474 │
│ grammars/tree-sitter-ruby/test/highlight/literals.rb                              │         475 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/gradle.plugin.bash   │         475 │
│ grammars/tree-sitter-php/test/highlight/keywords.php                              │         478 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/ruby.plugin.bash     │         478 │
│ grammars/tree-sitter-bash/examples/bash-it/test/run                               │         488 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/hg.plugin.bash       │         491 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/simple/simple.theme.bash        │         493 │
│ grammars/tree-sitter-bash/examples/bash-it/test/README.md                         │         494 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/pete/pete.theme.bash            │         495 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/.appveyor.yml       │         496 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/rails.plugin.bash    │         497 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │         501 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/roderik/roderik.theme.bash      │         503 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/vim.aliases.bash     │         523 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/rake.completion.+ │         533 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/pro/pro.theme.bash              │         538 │
│ grammars/tree-sitter-c/test/highlight/names.c                                     │         539 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │         540 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/yarn.aliases.bash    │         540 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/CHANGELOG.md        │         543 │
│ grammars/tree-sitter-bash/examples/bash-it/lib/history.bash                       │         544 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/envy/envy.theme.bash            │         553 │
│ grammars/tree-sitter-bash/examples/bash-it/lib/appearance.bash                    │         553 │
│ grammars/tree-sitter-java/test/highlight/types.java                               │         570 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/standard/standard.theme.bash    │         573 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/duru/duru.theme.bash            │         574 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/npm.aliases.bash     │         574 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │         577 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/rails.aliases.bash   │         590 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/vagrant.aliases.bash │         595 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/test_helper.b+ │         601 │
│ grammars/tree-sitter-cpp/test/corpus/microsoft.txt                                │         603 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/90210/90210.theme.bash          │         617 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/tylenol/tylenol.theme.bash      │         630 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/morris/morris.theme.bash        │         644 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/sirup/sirup.theme.bash          │         646 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/heroku.aliases.bash  │         647 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/autojump.plugin.bash │         652 │
│ grammars/tree-sitter-bash/examples/release.sh                                     │         657 │
│ grammars/tree-sitter-bash/examples/relocate.sh                                    │         665 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │         665 │
│ .github/workflows/rust.yml                                                        │         668 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/docker-compose.plug+ │         677 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/rvm.plugin.bash      │         693 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/n0qorg/n0qorg.theme.bash        │         698 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/z_autoenv.plugin.ba+ │         704 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/gulp.completion.+ │         718 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/install.sh          │         732 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/virtualenv.plugin.b+ │         745 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/wanelo/wanelo.theme.bash        │         751 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/bobby-python/bobby-python.them+ │         764 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/apt.aliases.bash     │         773 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/curl.aliases.bash    │         775 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/capistrano.compl+ │         781 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/homesick.aliases.ba+ │         787 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/rainbowbrite/rainbowbrite.them+ │         800 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/xterm.plugin.bash    │         801 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/less-pretty-cat.plu+ │         801 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/python.plugin.bash   │         811 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/nvm.plugin.bash      │         814 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/system.completio+ │         816 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-plain/powerline-plai+ │         824 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/explain.plugin.bash  │         857 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/purity/purity.theme.bash        │         861 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/projects.complet+ │         866 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/test_kitchen.com+ │         878 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │         895 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/CHANGELOG.md      │         937 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/brunton/brunton.theme.bash      │         957 │
│ grammars/tree-sitter-bash/examples/bash-it/uninstall.sh                           │         961 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/terraform.comple+ │         964 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │         973 │
│ grammars/tree-sitter-ruby/test/corpus/comments.txt                                │         980 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/fzf.plugin.bash      │         982 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler_random_colors/README.+ │         986 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/luan/luan.theme.bash            │         991 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/bakke/bakke.theme.bash          │         991 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/axin/axin.theme.bash            │        1007 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/redline/README.md               │        1008 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/jitsu.aliases.bash   │        1032 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/fasd.plugin.bash     │        1037 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/emperor/emperor.theme.bash      │        1043 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/src/error.bash   │        1044 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/gem.completion.b+ │        1061 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-exec-+ │        1078 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/modern/modern.theme.bash        │        1088 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │        1120 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-prepr+ │        1139 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/javascript.plugin.b+ │        1145 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/modern-t/modern-t.theme.bash    │        1152 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/bobby/bobby.theme.bash          │        1175 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/CHANGELOG.md     │        1227 │
│ grammars/tree-sitter-python/examples/tabs.py                                      │        1236 │
│ .github/workflows/publish_optimized_binary.yml                                    │        1243 │
│ grammars/tree-sitter-ruby/test/corpus/statements.txt                              │        1247 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/sexy/sexy.theme.bash            │        1259 │
│ grammars/tree-sitter-php/test/corpus/types.txt                                    │        1263 │
│ grammars/tree-sitter-bash/examples/bash-it/test/plugins/ruby.plugin.bats          │        1263 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/p4helpers.theme.bash            │        1265 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/clean/clean.theme.bash          │        1273 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/mbriggs/mbriggs.theme.bash      │        1278 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler/nwinkler.theme.bash    │        1282 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/ssh.completion.b+ │        1283 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/bundler.completi+ │        1284 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/nginx.plugin.bash    │        1296 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │        1300 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/drush.completion+ │        1321 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/projects.plugin.bash │        1322 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/kitsune/kitsune.theme.bash      │        1326 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/cooperkid/cooperkid.theme.bash  │        1352 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/invoke.completio+ │        1354 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-plain/powerline-plai+ │        1371 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/phoenix.aliases.bash │        1380 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/maven.completion+ │        1398 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/percol.plugin.bash   │        1420 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/tonka/tonka.theme.bash          │        1462 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline/powerline.theme.bash  │        1475 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/browser.plugin.bash  │        1477 │
│ grammars/tree-sitter-java/test/corpus/types.txt                                   │        1482 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-naked/powerline-nake+ │        1516 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/docker.aliases.bash  │        1516 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/grunt.completion+ │        1547 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/vault.completion+ │        1595 │
│ grammars/tree-sitter-bash/examples/bash-it/test/themes/base.theme.bats            │        1606 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │        1608 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/zitron/zitron.theme.bash        │        1672 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/gallifrey/gallifrey.theme.bash  │        1677 │
│ grammars/tree-sitter-java/script/run-javaparser/target/classes/RunJavaParser.cla+ │        1697 │
│ grammars/tree-sitter-bash/examples/bash-it/template/bash_profile.template.bash    │        1697 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/homesick.complet+ │        1714 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/iterate/iterate.theme.bash      │        1718 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/font/font.theme.bash            │        1718 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/redline/redline.theme.bash      │        1724 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/suite.bats     │        1751 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/apm.completion.b+ │        1775 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-multiline/powerline-+ │        1782 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/postgres.plugin.bash │        1853 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/sdkman.completio+ │        1859 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/50-assert-10-+ │        1922 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/extract.plugin.bash  │        1938 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/slick/slick.theme.bash          │        1963 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/50-assert-11-+ │        1976 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/pure/pure.theme.bash            │        1994 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/laravel.aliases.bash │        2030 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/src/lang.bash    │        2031 │
│ grammars/tree-sitter-c/test/corpus/types.txt                                      │        2040 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/osx.aliases.bash     │        2062 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/liquidprompt/liquidprompt.them+ │        2077 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/src/file.bash       │        2084 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │        2118 │
│ grammars/tree-sitter-bash/examples/bash-it/test/plugins/base.plugin.bats          │        2136 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/LICENSE             │        2143 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-multiline/powerline-+ │        2147 │
│ grammars/tree-sitter-bash/examples/bash-it/test/test_helper.bash                  │        2148 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/52-lang-10+ │        2153 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/zork/zork.theme.bash            │        2195 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/doubletime/doubletime.theme.ba+ │        2224 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/binaryanomaly/binaryanomaly.th+ │        2224 │
│ grammars/tree-sitter-php/test/corpus/literals.txt                                 │        2232 │
│ grammars/tree-sitter-php/test/corpus/interpolation.txt                            │        2252 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/51-temp-10-te+ │        2268 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/django.completio+ │        2280 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/cupcake/cupcake.theme.bash      │        2282 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/docker.plugin.bash   │        2384 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-+ │        2402 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/general.aliases.bash │        2406 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/osx.plugin.bash      │        2450 │
│ grammars/tree-sitter-bash/examples/test.sh                                        │        2481 │
│ grammars/tree-sitter-bash/examples/bash-it/test/install/install.bats              │        2483 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/dirs.plugin.bash     │        2486 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/brainy/README.md                │        2492 │
│ grammars/tree-sitter-bash/examples/bash-it/test/lib/search.bats                   │        2594 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/osx-timemachine.plu+ │        2612 │
│ grammars/tree-sitter-java/script/run-javaparser/target/run-javaparser-1.0-SNAPSH+ │        2619 │
│ grammars/tree-sitter-bash/examples/bash-it/DEVELOPMENT.md                         │        2619 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/git.aliases.bash     │        2649 │
│ grammars/tree-sitter-cpp/test/corpus/ambiguities.txt                              │        2654 │
│ grammars/tree-sitter-bash/examples/bash-it/test/install/uninstall.bats            │        2657 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-plain/README.md       │        2659 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-forma+ │        2766 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.1.ronn     │        2851 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/rjorgenson/rjorgenson.theme.ba+ │        2870 │
│ .gitmodules                                                                       │        2918 │
│ grammars/tree-sitter-bash/examples/bash-it/bash_it.sh                             │        2973 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler_random_colors/nwinkle+ │        2991 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-naked/README.md       │        3073 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/mairan/mairan.theme.bash        │        3076 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/sshagent.plugin.bash │        3096 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.1          │        3150 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/aws.plugin.bash      │        3189 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/dulcie/dulcie.theme.bash        │        3197 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/todo.completion.+ │        3234 │
│ grammars/tree-sitter-bash/examples/doc-build.sh                                   │        3260 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats        │        3325 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/bin/bats            │        3325 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/CONDUCT.md          │        3398 │
│ grammars/tree-sitter-bash/examples/atom.sh                                        │        3410 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/bash-it.completi+ │        3449 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline/README.md             │        3469 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/demula/demula.theme.bash        │        3473 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/git_flow.complet+ │        3497 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/virsh.completion+ │        3538 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/githelpers.theme.bash           │        3844 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline-multiline/README.md   │        4015 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/alias-completion.pl+ │        4088 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/51-temp-11-te+ │        4139 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/atomic/README.md                │        4172 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/packer.completio+ │        4206 │
│ grammars/tree-sitter-bash/examples/clean-old.sh                                   │        4258 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/battery.plugin.bash  │        4336 │
│ grammars/tree-sitter-cpp/test/corpus/types.txt                                    │        4351 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/src/temp.bash       │        4419 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.7.ronn     │        4510 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/z.plugin.bash        │        4560 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/jboss7.completio+ │        4623 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/fabric-completio+ │        4644 │
│ grammars/tree-sitter-cpp/test/corpus/definitions.txt                              │        4653 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/colors.theme.bash               │        4733 │
│ grammars/tree-sitter-cpp/examples/marker-index.h                                  │        4832 │
│ grammars/tree-sitter-c/test/corpus/ambiguities.txt                                │        4849 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.7          │        4895 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/composer.complet+ │        5099 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/virtualbox.compl+ │        5140 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/powerline/powerline.base.bash   │        5174 │
│ grammars/tree-sitter-c/test/corpus/microsoft.txt                                  │        5198 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │        5226 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/README.md        │        5353 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/rana/rana.theme.bash            │        5402 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/vagrant.completi+ │        5423 │
│ grammars/tree-sitter-bash/examples/bash-it/install.sh                             │        5549 │
│ grammars/tree-sitter-php/test/corpus/declarations.txt                             │        5600 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/defaults.complet+ │        5651 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/base.plugin.bash     │        5718 │
│ grammars/tree-sitter-java/test/corpus/literals.txt                                │        5792 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/tmux.completion.+ │        5793 │
│ grammars/tree-sitter-bash/examples/install.sh                                     │        6239 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/README.md           │        6291 │
│ grammars/tree-sitter-bash/examples/bash-it/CONTRIBUTING.md                        │        6311 │
│ grammars/tree-sitter-c/test/corpus/preprocessor.txt                               │        6405 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/hawaii50/hawaii50.theme.bash    │        6487 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/LICENSE          │        6555 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/LICENSE             │        6555 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/LICENSE           │        6555 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/src/output.bash  │        6604 │
│ grammars/tree-sitter-bash/examples/bash-it/lib/search.bash                        │        6614 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │        6817 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/go.completion.ba+ │        6843 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/brainy/brainy.theme.bash        │        6953 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/jekyll.plugin.bash   │        6984 │
│ grammars/tree-sitter-ruby/test/corpus/control-flow.txt                            │        7196 │
│ grammars/tree-sitter-bash/examples/bash-it/lib/preexec.bash                       │        7265 │
│ grammars/tree-sitter-c/test/corpus/statements.txt                                 │        7284 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/git.plugin.bash      │        7488 │
│ grammars/tree-sitter-bash/examples/bash-it/test/plugins/battery.plugin.bats       │        7551 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-exec-+ │        7934 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/atomic/atomic.theme.bash        │        7977 │
│ grammars/tree-sitter-php/test/corpus/statements.txt                               │        8003 │
│ grammars/tree-sitter-bash/examples/bash-it/aliases/available/pyrocms.aliases.bash │        8068 │
│ grammars/tree-sitter-cpp/test/corpus/statements.txt                               │        8117 │
│ grammars/tree-sitter-cpp/examples/rule.cc                                         │        8448 │
│ grammars/tree-sitter-bash/examples/bash-it/test/themes/base.theme.git.bats        │        8593 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/bats.bats      │        8610 │
│ grammars/tree-sitter-ruby/test/corpus/declarations.txt                            │        8641 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/gif.plugin.bash      │        9049 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/git_flow_avh.com+ │        9243 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/gh.completion.ba+ │        9292 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │        9466 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/hub.completion.b+ │        9543 │
│ grammars/tree-sitter-bash/examples/bash-it/plugins/available/proxy.plugin.bash    │        9580 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-1+ │        9786 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/salt.completion.+ │       10078 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/docker-machine.c+ │       10347 │
│ grammars/tree-sitter-bash/examples/bash-it/lib/composure.bash                     │       10922 │
│ grammars/tree-sitter-python/test/corpus/literals.txt                              │       11331 │
│ grammars/tree-sitter-c/test/corpus/declarations.txt                               │       11354 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/README.md           │       11687 │
│ grammars/tree-sitter-php/test/corpus/expressions.txt                              │       11817 │
│ grammars/tree-sitter-c/examples/malloc.c                                          │       12098 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/docker-compose.c+ │       12140 │
│ grammars/tree-sitter-go/examples/letter_test.go                                   │       12438 │
│ grammars/tree-sitter-c/test/corpus/expressions.txt                                │       13125 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/gradle.completio+ │       13724 │
│ grammars/tree-sitter-java/test/corpus/declarations.txt                            │       13890 │
│ grammars/tree-sitter-bash/examples/bash-it/test/bash_it/bash_it.bats              │       14277 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/base.theme.bash                 │       15042 │
│ grammars/tree-sitter-python/test/corpus/expressions.txt                           │       15254 │
│ grammars/tree-sitter-bash/examples/bash-it/test/completion/bash-it.completion.ba+ │       15258 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/README.md         │       16050 │
│ grammars/tree-sitter-bash/examples/bash-it/lib/helpers.bash                       │       17048 │
│ assets/rust_example.png                                                           │       17111 │
│ grammars/tree-sitter-java/test/corpus/expressions.txt                             │       18491 │
│ grammars/tree-sitter-cpp/test/corpus/expressions.txt                              │       19980 │
│ grammars/tree-sitter-python/test/corpus/statements.txt                            │       20197 │
│ grammars/tree-sitter-bash/examples/bash-it/README.md                              │       20625 │
│ grammars/tree-sitter-ruby/test/corpus/literals.txt                                │       22103 │
│ grammars/tree-sitter-bash/examples/bash-it/test/lib/helpers.bats                  │       22407 │
│ grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/src/assert.bash   │       22640 │
│ grammars/tree-sitter-ruby/test/corpus/expressions.txt                             │       28130 │
│ grammars/tree-sitter-cpp/test/corpus/declarations.txt                             │       30689 │
│ grammars/tree-sitter-python/examples/python3-grammar.py                           │       30784 │
│ grammars/tree-sitter-python/examples/python2-grammar.py                           │       30981 │
│ grammars/tree-sitter-python/examples/python3-grammar-crlf.py                      │       31722 │
│ grammars/tree-sitter-python/examples/python2-grammar-crlf.py                      │       31929 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler_random_colors/screens+ │       43510 │
│ grammars/tree-sitter-c/examples/parser.c                                          │       44479 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/svn.completion.b+ │       44924 │
│ grammars/tree-sitter-python/examples/python3.8_grammar.py                         │       50403 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/git.completion.b+ │       57446 │
│ grammars/tree-sitter-rust/examples/ast.rs                                         │       65500 │
│ grammars/tree-sitter-go/examples/value.go                                         │       73937 │
│ grammars/tree-sitter-bash/examples/bash-it/completion/available/docker.completio+ │      103280 │
│ grammars/tree-sitter-go/examples/proc.go                                          │      118832 │
│ grammars/tree-sitter-css/examples/atom.io.css                                     │      144668 │
│ grammars/tree-sitter-css/examples/github.com.css                                  │      150235 │
│ grammars/tree-sitter-c/examples/cluster.c                                         │      216674 │
│ grammars/tree-sitter-bash/examples/bash-it/themes/redline/screenshot.png          │      984714 │
└───────────────────────────────────────────────────────────────────────────────────┴─────────────┘
Saved 6% or 3.5 MB in 502 files (of 57.9 MB and 809 files in entire crate)
```