### PR TITLE
Fix reference to matrix variable

### DIFF
--- a/.github/workflows/publish_optimized_binary.yml
+++ b/.github/workflows/publish_optimized_binary.yml
@@ -40,7 +40,7 @@ jobs:
           key: ${{ runner.os }}-cargo-optimized-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install zip (Windows)
-        if: matrix.triple.os == 'windows-latest'
+        if: matrix.os == 'windows-latest'
         uses: crazy-max/ghaction-chocolatey@v1.4.0
         with:
           args: install -y zip


### PR DESCRIPTION
Correct a typo that was causing a nonexistent matrix variable to be
accessed. This will fix the install step for `zip` on Windows.
