### PR TITLE
Conditional compilation for build-info

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           command: build
           use-cross: ${{ matrix.job.use-cross }}
-          args: --release --locked --target ${{ matrix.job.target }}
+          args: --release --locked --target ${{ matrix.job.target }} --features better-build-info
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         command: build
         use-cross: ${{ matrix.job.use-cross }}
-        args: --target ${{ matrix.job.target }}
+        args: --target ${{ matrix.job.target }} --features better-build-info
     - name: Unit tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ pretty_env_logger = "0.4.0"
 log = { version = "0.4.14", features = ["std"] }
 thiserror = "1.0.26"
 logging_timer = "1.0.0"
-build-info = "0.0.24"
+build-info = { version = "0.0.24", optional = true }
 jemallocator = { version = "0.3.2", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -64,7 +64,10 @@ phf = { version = "0.9.0", features = ["macros"] }
 anyhow = "1.0.41"
 cargo-emit = "0.1.1"
 rayon = "1.5.1"
-build-info-build = "0.0.24"
+build-info-build = { version = "0.0.24", optional = true }
 
 [profile.release]
 lto = "thin"
+
+[features]
+better-build-info = ["build-info", "build-info-build"]

--- a/build.rs
+++ b/build.rs
@@ -241,6 +241,7 @@ use phf::phf_map;
     let codegen_path = Path::new(&codegen_out_dir).join("generated_grammar.rs");
     fs::write(&codegen_path, codegen)?;
 
+    #[cfg(feature = "better-build-info")]
     build_info_build::build_script();
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,6 +90,7 @@ pub enum Command {
     DumpDefaultConfig,
 
     /// Print extended build information
+    #[cfg(feature = "better-build-info")]
     BuildInfo,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use std::{
     path::PathBuf,
 };
 
+#[cfg(feature = "better-build-info")]
 build_info::build_info!(fn build_info);
 
 #[cfg(feature = "jemallocator")]
@@ -154,6 +155,7 @@ fn dump_default_config() -> Result<()> {
 }
 
 /// Print extended version information to the terminal
+#[cfg(feature = "better-build-info")]
 fn print_build_info() {
     println!(
         "{}",
@@ -176,6 +178,8 @@ fn main(args: Args) -> Result<()> {
         match cmd {
             Command::List => list_supported_languages(),
             Command::DumpDefaultConfig => dump_default_config()?,
+
+            #[cfg(feature = "better-build-info")]
             Command::BuildInfo => print_build_info(),
         }
     } else {


### PR DESCRIPTION
Conditionally build `build-info` so we don't have to waste time
compiling it in development mode, as it isn't really used in dev.
