### PR TITLE
style: remove unnecessary borrow

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,7 @@ fn compile_grammar(
             .include(include)
             .files(c_sources)
             .warnings(false)
-            .try_compile(&output_name)?;
+            .try_compile(output_name)?;
     }
     Ok(())
 }


### PR DESCRIPTION
This addresses a clippy lint. The borrow is unnecessary because it's
immediately dereferenced by the compiler.
