### PR TITLE
refactor: clean up build script, better errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ phf = { version = "0.9.0", features = ["macros"] }
 anyhow = "1.0.42"
 cargo-emit = "0.1.1"
 rayon = "1.5.1"
+thiserror = "1.0.26"
 build-info-build = { version = "0.0.24", optional = true }
 
 [profile.release]


### PR DESCRIPTION
* Make the build script more modular by splitting out more functions from
  the main loop
* Clearer errors when files don't exist

Example error from build script when a subdirectory is missing:

```
   Compiling diffsitter v0.6.7-alpha.0 (/Users/afnan/dev/diffsitter)
error: failed to run custom build command for `diffsitter v0.6.7-alpha.0 (/Users/afnan/dev/diffsitter)`

Caused by:
  process didn't exit successfully: `/Users/afnan/dev/diffsitter/target/debug/build/diffsitter-93ac4cc2550cb1c3/build-script-build` (exit status: 1)
  --- stderr
  Error: Subdirectory for grammar bash was not found
```

Example error from build script when specific source files are missing:

```
   Compiling diffsitter v0.6.7-alpha.0 (/Users/afnan/dev/diffsitter)
error: failed to run custom build command for `diffsitter v0.6.7-alpha.0 (/Users/afnan/dev/diffsitter)`

Caused by:
  process didn't exit successfully: `/Users/afnan/dev/diffsitter/target/debug/build/diffsitter-93ac4cc2550cb1c3/build-script-build` (exit status: 1)
  --- stderr
  Error: Source files ["grammars/tree-sitter-bash/src/parser.c"] not found for bash
```