### PR TITLE
Update the release cache key

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -98,7 +98,7 @@ jobs:
           args: --release --locked --target ${{ matrix.job.target }} --features better-build-info
       - uses: Swatinem/rust-cache@v1
         with:
-          key: ${{ matrix.job.target }}
+          key: ${{ matrix.job.target }}-release
       - name: Install packages (Windows)
         if: matrix.job.os == 'windows-latest'
         uses: crazy-max/ghaction-chocolatey@v1.4.0


### PR DESCRIPTION
Currently both the debug and release builds use the same key, which is
not correct. This commit allows the CI and CD pipelines to use different
caches.
