### PR TITLE
ci: enforce formatting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,11 @@ jobs:
     - uses: Swatinem/rust-cache@v1
       with:
           key: ${{ matrix.job.target }}
+    - name: Check formatting
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
     - name: Build
       uses: actions-rs/cargo@v1
       with:

--- a/build.rs
+++ b/build.rs
@@ -286,7 +286,7 @@ fn main() -> Result<()> {
             path: PathBuf::from("grammars/tree-sitter-typescript/tsx"),
             c_sources: vec!["parser.c", "scanner.c"],
             cpp_sources: vec![],
-        },
+        }, // Add new grammars here...
     ];
 
     // The string represented the generated code that we get from the tree sitter grammars


### PR DESCRIPTION
Enforce formatting in the CI and run `cargo fmt --all` on the codebase.
