### PR TITLE
fix: Language listing bug

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -335,7 +335,7 @@ pub fn parse_file(
 #[cfg(feature = "static-grammar-libs")]
 pub fn supported_languages() -> Vec<&'static str> {
     if cfg!(feature = "static-grammar-libs") {
-        let mut keys: Vec<&'static str> = Vec::new();
+        let mut keys: Vec<&'static str> = LANGUAGES.keys().copied().collect();
         keys.sort_unstable();
         keys
     } else {


### PR DESCRIPTION
This corrects an error from an oversight earlier where the vector used
to list all of the languages was an empty vector, rather than the keys
from the grammar map.
