### PR TITLE
feature: Add support for a diff fallback command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,21 @@ build = "build.rs"
 homepage = "https://github.com/afnanenayet/diffsitter"
 repository = "https://github.com/afnanenayet/diffsitter"
 include = [
-    "src/**/*",
-    "LICENSE",
-    "README.md",
-    "grammars/**/*.c",
-    "grammars/**/*.cc",
-    "grammars/**/*.cpp",
-    "grammars/**/*.h",
-    "grammars/**/*.hpp",
-    "build.rs",
-    "!**/*.png",
-    "!**/test/**/*",
-    "!**/*_test.*",
-    "!**/examples/**/*",
-    "!**/target/**/*",
-    "!assets/*"
+  "src/**/*",
+  "LICENSE",
+  "README.md",
+  "grammars/**/*.c",
+  "grammars/**/*.cc",
+  "grammars/**/*.cpp",
+  "grammars/**/*.h",
+  "grammars/**/*.hpp",
+  "build.rs",
+  "!**/*.png",
+  "!**/test/**/*",
+  "!**/*_test.*",
+  "!**/examples/**/*",
+  "!**/target/**/*",
+  "!assets/*",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/assets/sample_config.json5
+++ b/assets/sample_config.json5
@@ -51,4 +51,11 @@
             "cpp": "../libtree-sitter-cpp.so",
         },
     },
+    // Specify a fallback command if diffsitter can't parse the given input
+    // files. This is invoked by diffsitter as:
+    //
+    // ```sh
+    // ${fallback_cmd} ${old} ${new}
+    // ```
+    "fallback-cmd": "diff",
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,16 @@ pub struct Config {
 
     /// Options for loading
     pub grammar: GrammarConfig,
+
+    /// The program to invoke if the given files can not be parsed by the available tree-sitter
+    /// parsers.
+    ///
+    /// This will invoke the program with with the old and new file as arguments, like so:
+    ///
+    /// ```sh
+    /// ${FALLBACK_PROGRAM} ${OLD} ${NEW}
+    /// ```
+    pub fallback_cmd: Option<String>,
 }
 
 /// The possible errors that can arise when attempting to read a config

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -186,7 +186,7 @@ fn generate_language_dynamic(
 #[allow(clippy::vec_init_then_push)]
 // `config` is not used if the `dynamic-grammar-libs` build flag isn't enabled
 #[allow(unused)]
-fn generate_language(lang: &str, config: &GrammarConfig) -> Result<Language, LoadingError> {
+pub fn generate_language(lang: &str, config: &GrammarConfig) -> Result<Language, LoadingError> {
     // The candidates for the grammar, in order of precedence.
     let mut grammar_candidates = Vec::new();
 


### PR DESCRIPTION
Allow users to configure a diff fallback command to invoke if
`diffsitter` can't parse the input types.

This also updates the sample config with an example of the new
configuration options.

Addresses #160.
