### PR TITLE
fix: Use forked typescript module to fix publish

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/afnanenayet/tree-sitter-ocaml.git
 [submodule "grammars/tree-sitter-typescript"]
 	path = grammars/tree-sitter-typescript
-	url = https://github.com/tree-sitter/tree-sitter-typescript.git
+	url = https://github.com/afnanenayet/tree-sitter-typescript.git
 [submodule "grammars/tree-sitter-verilog"]
 	path = grammars/tree-sitter-verilog
 	url = https://github.com/tree-sitter/tree-sitter-verilog.git


### PR DESCRIPTION
Use a forked typescript grammar that removes rust binding code to fix
the publish step
