### PR TITLE
fix: Fix typo with variable name

### DIFF
--- a/deployment/macos/homebrew/homebrew_formula.rb.template
+++ b/deployment/macos/homebrew/homebrew_formula.rb.template
@@ -3,7 +3,7 @@ class Diffsitter < Formula
   homepage "https://github.com/afnanenayet/diffsitter"
   version "$short_version"
   url "https://github.com/afnanenayet/diffsitter/releases/download/$version/diffsitter-x86_64-apple-darwin.tar.gz"
-  sha256 "$shachecksum"
+  sha256 "$checksum"
   license "MIT"
 
   def install


### PR DESCRIPTION
Use the correct variable name to ensure that the SHA checksum is
subsituted into the template.
