### PR TITLE
docs: Fix typo with config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ brief help messages).
 You can configure file associations and formatting options for `diffsitter`
 using a config file. If a config is not supplied, the app will use the default
 config, which you can see with `diffsitter --cmd dump_default_config`. It will
-look for a config at `${XDG_HOME:-$HOME}/.config` on macOS and Linux, and the
-standard directory for Windows. You can also refer to the
-[sample config](/assets/sample_config.json5).
+look for a config at `${XDG_HOME:-$HOME}/.config/diffsitter/config.json5` on
+macOS and Linux, and the standard directory for Windows. You can also refer to
+the [sample config](/assets/sample_config.json5).
 
 You can override the default config path by using the `--config` flag or set
 the `DIFFSITTER_CONFIG` environment variable.


### PR DESCRIPTION
Correct the config path so it uses the full path.
