### PR TITLE
docs: Update README badge for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/afnanenayet/diffsitter/actions/workflows/CI.yml/badge.svg)](https://github.com/afnanenayet/diffsitter/actions/workflows/CI.yml)
 [![CD](https://github.com/afnanenayet/diffsitter/actions/workflows/CD.yml/badge.svg)](https://github.com/afnanenayet/diffsitter/actions/workflows/CD.yml)
 [![crates version](https://img.shields.io/crates/v/diffsitter)](https://crates.io/crates/diffsitter)
-[![latest tag](https://img.shields.io/github/v/tag/afnanenayet/diffsitter?label=release)](https://github.com/afnanenayet/diffsitter/releases/latest)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/afnanenayet/diffsitter)](https://github.com/afnanenayet/diffsitter/releases/latest)
 ![downloads](https://img.shields.io/crates/d/diffsitter)
 [![license](https://img.shields.io/github/license/afnanenayet/diffsitter)](./LICENSE)
 


### PR DESCRIPTION
The latest release badge no longer includes nightly/pre-release builds.
