### PR TITLE
fix: Add subdirectory to src archive, use gzip

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -290,7 +290,7 @@ jobs:
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         shell: bash
         run: |
-          bash deployment/git-archive-all.bash diffsitter_src.tar.gz
+          bash deployment/git-archive-all.bash --prefix "diffsitter_src/" --format tar.gz diffsitter_src.tar.gz
 
       - name: Upload tarball with submodules
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'


### PR DESCRIPTION
As noted in #261, the tar command does not use a subdirectory. This adds a subdirectory to the archive to be better behaved. The archive now uses `gzip` as the filename would imply.

I tested this by creating a test release (`ci-test`) for this branch and downloading the source tarball generated by the release.

I ran `tar -xzvf` on the output source file (`diffsitter_src.tar.gz`) and can confirm that it deflates properly and into a directory.

<details>
<summary>Test output</summary>

```
❯ tar -xzvf diffsitter_src.tar.gz
x diffsitter_src/
x diffsitter_src/.github/
x diffsitter_src/.github/ISSUE_TEMPLATE/
x diffsitter_src/.github/ISSUE_TEMPLATE/bug_report.md
x diffsitter_src/.github/ISSUE_TEMPLATE/feature_request.md
x diffsitter_src/.github/dependabot.yml
x diffsitter_src/.github/workflows/
x diffsitter_src/.github/workflows/CD.yml
x diffsitter_src/.github/workflows/CI.yml
x diffsitter_src/.github/workflows/post-deploy.yml
x diffsitter_src/.gitignore
x diffsitter_src/.gitmodules
x diffsitter_src/CODEOWNERS
x diffsitter_src/Cargo.lock
x diffsitter_src/Cargo.toml
x diffsitter_src/Cross.toml
x diffsitter_src/LICENSE
x diffsitter_src/README.md
x diffsitter_src/assets/
x diffsitter_src/assets/rust_example.png
x diffsitter_src/assets/rust_example_logs.png
x diffsitter_src/assets/sample_config.json5
x diffsitter_src/bin/
x diffsitter_src/bin/git-diffsitter
x diffsitter_src/build.rs
x diffsitter_src/clippy.toml
x diffsitter_src/deployment/
x diffsitter_src/deployment/brew_packager.py
x diffsitter_src/deployment/git-archive-all.bash
x diffsitter_src/deployment/macos/
x diffsitter_src/deployment/macos/homebrew/
x diffsitter_src/deployment/macos/homebrew/homebrew_formula.rb.template
x diffsitter_src/docs/
x diffsitter_src/docs/CODE_OF_CONDUCT.md
x diffsitter_src/docs/CONTRIBUTING.md
x diffsitter_src/grammars/
x diffsitter_src/grammars/tree-sitter-bash/
x diffsitter_src/grammars/tree-sitter-c/
x diffsitter_src/grammars/tree-sitter-c-sharp/
x diffsitter_src/grammars/tree-sitter-cpp/
x diffsitter_src/grammars/tree-sitter-css/
x diffsitter_src/grammars/tree-sitter-go/
x diffsitter_src/grammars/tree-sitter-hcl/
x diffsitter_src/grammars/tree-sitter-java/
x diffsitter_src/grammars/tree-sitter-json/
x diffsitter_src/grammars/tree-sitter-ocaml/
x diffsitter_src/grammars/tree-sitter-php/
x diffsitter_src/grammars/tree-sitter-python/
x diffsitter_src/grammars/tree-sitter-ruby/
x diffsitter_src/grammars/tree-sitter-rust/
x diffsitter_src/grammars/tree-sitter-typescript/
x diffsitter_src/rustfmt.toml
x diffsitter_src/src/
x diffsitter_src/src/ast.rs
x diffsitter_src/src/cli.rs
x diffsitter_src/src/config.rs
x diffsitter_src/src/diff.rs
x diffsitter_src/src/formatting.rs
x diffsitter_src/src/main.rs
x diffsitter_src/src/neg_idx_vec.rs
x diffsitter_src/src/parse.rs
x diffsitter_src/src/snapshots/
x diffsitter_src/src/snapshots/diffsitter__tests__diff_hunks_snapshot___short_python_py_-2.snap
x diffsitter_src/src/snapshots/diffsitter__tests__diff_hunks_snapshot___short_python_py_.snap
x diffsitter_src/src/snapshots/diffsitter__tests__diff_hunks_snapshot___short_rust_rs_-2.snap
x diffsitter_src/src/snapshots/diffsitter__tests__diff_hunks_snapshot___short_rust_rs_.snap
x diffsitter_src/test_data/
x diffsitter_src/test_data/short/
x diffsitter_src/test_data/short/python/
x diffsitter_src/test_data/short/python/a.py
x diffsitter_src/test_data/short/python/b.py
x diffsitter_src/test_data/short/rust/
x diffsitter_src/test_data/short/rust/a.rs
x diffsitter_src/test_data/short/rust/b.rs
x diffsitter_src/grammars/tree-sitter-css/
x diffsitter_src/grammars/tree-sitter-css/.appveyor.yml
x diffsitter_src/grammars/tree-sitter-css/.gitattributes
x diffsitter_src/grammars/tree-sitter-css/.gitignore
x diffsitter_src/grammars/tree-sitter-css/.npmignore
x diffsitter_src/grammars/tree-sitter-css/.travis.yml
x diffsitter_src/grammars/tree-sitter-css/LICENSE
x diffsitter_src/grammars/tree-sitter-css/README.md
x diffsitter_src/grammars/tree-sitter-css/binding.gyp
x diffsitter_src/grammars/tree-sitter-css/bindings/
x diffsitter_src/grammars/tree-sitter-css/bindings/node/
x diffsitter_src/grammars/tree-sitter-css/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-css/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-css/corpus/
x diffsitter_src/grammars/tree-sitter-css/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-css/corpus/selectors.txt
x diffsitter_src/grammars/tree-sitter-css/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-css/corpus/stylesheets.txt
x diffsitter_src/grammars/tree-sitter-css/examples/
x diffsitter_src/grammars/tree-sitter-css/examples/atom.io.css
x diffsitter_src/grammars/tree-sitter-css/examples/github.com.css
x diffsitter_src/grammars/tree-sitter-css/grammar.js
x diffsitter_src/grammars/tree-sitter-css/package.json
x diffsitter_src/grammars/tree-sitter-css/queries/
x diffsitter_src/grammars/tree-sitter-css/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-css/src/
x diffsitter_src/grammars/tree-sitter-css/src/grammar.json
x diffsitter_src/grammars/tree-sitter-css/src/node-types.json
x diffsitter_src/grammars/tree-sitter-css/src/parser.c
x diffsitter_src/grammars/tree-sitter-css/src/scanner.c
x diffsitter_src/grammars/tree-sitter-css/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-css/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-ocaml/
x diffsitter_src/grammars/tree-sitter-ocaml/.gitattributes
x diffsitter_src/grammars/tree-sitter-ocaml/.github/
x diffsitter_src/grammars/tree-sitter-ocaml/.github/workflows/
x diffsitter_src/grammars/tree-sitter-ocaml/.github/workflows/build.yml
x diffsitter_src/grammars/tree-sitter-ocaml/.gitignore
x diffsitter_src/grammars/tree-sitter-ocaml/LICENSE
x diffsitter_src/grammars/tree-sitter-ocaml/README.md
x diffsitter_src/grammars/tree-sitter-ocaml/binding.gyp
x diffsitter_src/grammars/tree-sitter-ocaml/bindings/
x diffsitter_src/grammars/tree-sitter-ocaml/bindings/node/
x diffsitter_src/grammars/tree-sitter-ocaml/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-ocaml/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-ocaml/bindings/node/interface.js
x diffsitter_src/grammars/tree-sitter-ocaml/bindings/node/ocaml.js
x diffsitter_src/grammars/tree-sitter-ocaml/common/
x diffsitter_src/grammars/tree-sitter-ocaml/common/scanner.h
x diffsitter_src/grammars/tree-sitter-ocaml/examples/
x diffsitter_src/grammars/tree-sitter-ocaml/examples/.gitkeep
x diffsitter_src/grammars/tree-sitter-ocaml/interface/
x diffsitter_src/grammars/tree-sitter-ocaml/interface/corpus/
x diffsitter_src/grammars/tree-sitter-ocaml/interface/corpus/module-items.txt
x diffsitter_src/grammars/tree-sitter-ocaml/interface/corpus/module-specification.txt
x diffsitter_src/grammars/tree-sitter-ocaml/interface/grammar.js
x diffsitter_src/grammars/tree-sitter-ocaml/interface/package.json
x diffsitter_src/grammars/tree-sitter-ocaml/interface/src/
x diffsitter_src/grammars/tree-sitter-ocaml/interface/src/grammar.json
x diffsitter_src/grammars/tree-sitter-ocaml/interface/src/node-types.json
x diffsitter_src/grammars/tree-sitter-ocaml/interface/src/parser.c
x diffsitter_src/grammars/tree-sitter-ocaml/interface/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-ocaml/interface/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-ocaml/interface/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/attributes.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/comments.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/module-expressions.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/module-implementation.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/module-items.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/module-types.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/patterns.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/toplevel.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/grammar.js
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/package.json
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/src/
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/src/grammar.json
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/src/node-types.json
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/src/parser.c
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-ocaml/ocaml/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-ocaml/package.json
x diffsitter_src/grammars/tree-sitter-ocaml/queries/
x diffsitter_src/grammars/tree-sitter-ocaml/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-ocaml/queries/locals.scm
x diffsitter_src/grammars/tree-sitter-ocaml/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-ocaml/script/
x diffsitter_src/grammars/tree-sitter-ocaml/script/known_failures.txt
x diffsitter_src/grammars/tree-sitter-ocaml/script/parse-examples
x diffsitter_src/grammars/tree-sitter-ocaml/test/
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/attributes.ml
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/constants.ml
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/functions.ml
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/locals.ml
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/modules.ml
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/operators.ml
x diffsitter_src/grammars/tree-sitter-ocaml/test/highlight/types.ml
x diffsitter_src/grammars/tree-sitter-json/
x diffsitter_src/grammars/tree-sitter-json/.gitattributes
x diffsitter_src/grammars/tree-sitter-json/.github/
x diffsitter_src/grammars/tree-sitter-json/.github/workflows/
x diffsitter_src/grammars/tree-sitter-json/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-json/.gitignore
x diffsitter_src/grammars/tree-sitter-json/.npmignore
x diffsitter_src/grammars/tree-sitter-json/LICENSE
x diffsitter_src/grammars/tree-sitter-json/README.md
x diffsitter_src/grammars/tree-sitter-json/binding.gyp
x diffsitter_src/grammars/tree-sitter-json/bindings/
x diffsitter_src/grammars/tree-sitter-json/bindings/node/
x diffsitter_src/grammars/tree-sitter-json/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-json/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-json/corpus/
x diffsitter_src/grammars/tree-sitter-json/corpus/main.txt
x diffsitter_src/grammars/tree-sitter-json/grammar.js
x diffsitter_src/grammars/tree-sitter-json/package.json
x diffsitter_src/grammars/tree-sitter-json/queries/
x diffsitter_src/grammars/tree-sitter-json/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-json/src/
x diffsitter_src/grammars/tree-sitter-json/src/grammar.json
x diffsitter_src/grammars/tree-sitter-json/src/node-types.json
x diffsitter_src/grammars/tree-sitter-json/src/parser.c
x diffsitter_src/grammars/tree-sitter-json/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-json/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-c/
x diffsitter_src/grammars/tree-sitter-c/.appveyor.yml
x diffsitter_src/grammars/tree-sitter-c/.gitattributes
x diffsitter_src/grammars/tree-sitter-c/.gitignore
x diffsitter_src/grammars/tree-sitter-c/.npmignore
x diffsitter_src/grammars/tree-sitter-c/.travis.yml
x diffsitter_src/grammars/tree-sitter-c/LICENSE
x diffsitter_src/grammars/tree-sitter-c/README.md
x diffsitter_src/grammars/tree-sitter-c/binding.gyp
x diffsitter_src/grammars/tree-sitter-c/bindings/
x diffsitter_src/grammars/tree-sitter-c/bindings/node/
x diffsitter_src/grammars/tree-sitter-c/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-c/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-c/examples/
x diffsitter_src/grammars/tree-sitter-c/examples/cluster.c
x diffsitter_src/grammars/tree-sitter-c/examples/malloc.c
x diffsitter_src/grammars/tree-sitter-c/examples/parser.c
x diffsitter_src/grammars/tree-sitter-c/grammar.js
x diffsitter_src/grammars/tree-sitter-c/package.json
x diffsitter_src/grammars/tree-sitter-c/queries/
x diffsitter_src/grammars/tree-sitter-c/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-c/src/
x diffsitter_src/grammars/tree-sitter-c/src/grammar.json
x diffsitter_src/grammars/tree-sitter-c/src/node-types.json
x diffsitter_src/grammars/tree-sitter-c/src/parser.c
x diffsitter_src/grammars/tree-sitter-c/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-c/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-c/test/
x diffsitter_src/grammars/tree-sitter-c/test/corpus/
x diffsitter_src/grammars/tree-sitter-c/test/corpus/ambiguities.txt
x diffsitter_src/grammars/tree-sitter-c/test/corpus/crlf.txt
x diffsitter_src/grammars/tree-sitter-c/test/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-c/test/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-c/test/corpus/microsoft.txt
x diffsitter_src/grammars/tree-sitter-c/test/corpus/preprocessor.txt
x diffsitter_src/grammars/tree-sitter-c/test/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-c/test/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-c/test/highlight/
x diffsitter_src/grammars/tree-sitter-c/test/highlight/keywords.c
x diffsitter_src/grammars/tree-sitter-c/test/highlight/names.c
x diffsitter_src/grammars/tree-sitter-go/
x diffsitter_src/grammars/tree-sitter-go/.gitattributes
x diffsitter_src/grammars/tree-sitter-go/.github/
x diffsitter_src/grammars/tree-sitter-go/.github/pull_request_template.md
x diffsitter_src/grammars/tree-sitter-go/.github/workflows/
x diffsitter_src/grammars/tree-sitter-go/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-go/.gitignore
x diffsitter_src/grammars/tree-sitter-go/.gitmodules
x diffsitter_src/grammars/tree-sitter-go/.npmignore
x diffsitter_src/grammars/tree-sitter-go/LICENSE
x diffsitter_src/grammars/tree-sitter-go/Makefile
x diffsitter_src/grammars/tree-sitter-go/README.md
x diffsitter_src/grammars/tree-sitter-go/binding.gyp
x diffsitter_src/grammars/tree-sitter-go/bindings/
x diffsitter_src/grammars/tree-sitter-go/bindings/c/
x diffsitter_src/grammars/tree-sitter-go/bindings/c/go.h
x diffsitter_src/grammars/tree-sitter-go/bindings/c/tree-sitter-go.pc.in
x diffsitter_src/grammars/tree-sitter-go/bindings/node/
x diffsitter_src/grammars/tree-sitter-go/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-go/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-go/corpus/
x diffsitter_src/grammars/tree-sitter-go/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-go/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-go/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-go/corpus/source_files.txt
x diffsitter_src/grammars/tree-sitter-go/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-go/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-go/examples/
x diffsitter_src/grammars/tree-sitter-go/examples/letter_test.go
x diffsitter_src/grammars/tree-sitter-go/examples/no_newline_at_eof.go
x diffsitter_src/grammars/tree-sitter-go/examples/proc.go
x diffsitter_src/grammars/tree-sitter-go/examples/value.go
x diffsitter_src/grammars/tree-sitter-go/grammar.js
x diffsitter_src/grammars/tree-sitter-go/package.json
x diffsitter_src/grammars/tree-sitter-go/queries/
x diffsitter_src/grammars/tree-sitter-go/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-go/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-go/script/
x diffsitter_src/grammars/tree-sitter-go/script/known-failures.txt
x diffsitter_src/grammars/tree-sitter-go/script/parse-examples
x diffsitter_src/grammars/tree-sitter-go/src/
x diffsitter_src/grammars/tree-sitter-go/src/grammar.json
x diffsitter_src/grammars/tree-sitter-go/src/node-types.json
x diffsitter_src/grammars/tree-sitter-go/src/parser.c
x diffsitter_src/grammars/tree-sitter-go/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-go/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-php/
x diffsitter_src/grammars/tree-sitter-php/.gitattributes
x diffsitter_src/grammars/tree-sitter-php/.github/
x diffsitter_src/grammars/tree-sitter-php/.github/pull_request_template.md
x diffsitter_src/grammars/tree-sitter-php/.github/workflows/
x diffsitter_src/grammars/tree-sitter-php/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-php/.gitignore
x diffsitter_src/grammars/tree-sitter-php/.npmignore
x diffsitter_src/grammars/tree-sitter-php/LICENSE
x diffsitter_src/grammars/tree-sitter-php/README.md
x diffsitter_src/grammars/tree-sitter-php/binding.gyp
x diffsitter_src/grammars/tree-sitter-php/bindings/
x diffsitter_src/grammars/tree-sitter-php/bindings/node/
x diffsitter_src/grammars/tree-sitter-php/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-php/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-php/grammar.js
x diffsitter_src/grammars/tree-sitter-php/package.json
x diffsitter_src/grammars/tree-sitter-php/queries/
x diffsitter_src/grammars/tree-sitter-php/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-php/queries/injections.scm
x diffsitter_src/grammars/tree-sitter-php/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-php/script/
x diffsitter_src/grammars/tree-sitter-php/script/known-failures.txt
x diffsitter_src/grammars/tree-sitter-php/script/parse-examples
x diffsitter_src/grammars/tree-sitter-php/script/parse-examples.js
x diffsitter_src/grammars/tree-sitter-php/src/
x diffsitter_src/grammars/tree-sitter-php/src/grammar.json
x diffsitter_src/grammars/tree-sitter-php/src/node-types.json
x diffsitter_src/grammars/tree-sitter-php/src/parser.c
x diffsitter_src/grammars/tree-sitter-php/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-php/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-php/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-php/test/
x diffsitter_src/grammars/tree-sitter-php/test/corpus/
x diffsitter_src/grammars/tree-sitter-php/test/corpus/class.txt
x diffsitter_src/grammars/tree-sitter-php/test/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-php/test/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-php/test/corpus/interpolation.txt
x diffsitter_src/grammars/tree-sitter-php/test/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-php/test/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-php/test/corpus/string.txt
x diffsitter_src/grammars/tree-sitter-php/test/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-php/test/highlight/
x diffsitter_src/grammars/tree-sitter-php/test/highlight/keywords.php
x diffsitter_src/grammars/tree-sitter-php/test/highlight/literals.php
x diffsitter_src/grammars/tree-sitter-php/test/highlight/types.php
x diffsitter_src/grammars/tree-sitter-c-sharp/
x diffsitter_src/grammars/tree-sitter-c-sharp/.gitattributes
x diffsitter_src/grammars/tree-sitter-c-sharp/.github/
x diffsitter_src/grammars/tree-sitter-c-sharp/.github/workflows/
x diffsitter_src/grammars/tree-sitter-c-sharp/.github/workflows/build.yml
x diffsitter_src/grammars/tree-sitter-c-sharp/.gitignore
x diffsitter_src/grammars/tree-sitter-c-sharp/.npmignore
x diffsitter_src/grammars/tree-sitter-c-sharp/LICENSE
x diffsitter_src/grammars/tree-sitter-c-sharp/README.md
x diffsitter_src/grammars/tree-sitter-c-sharp/binding.gyp
x diffsitter_src/grammars/tree-sitter-c-sharp/bindings/
x diffsitter_src/grammars/tree-sitter-c-sharp/bindings/node/
x diffsitter_src/grammars/tree-sitter-c-sharp/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-c-sharp/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/attributes.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/classes.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/contextual-keywords.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/enums.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/identifiers.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/interfaces.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/preprocessor.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/query-syntax.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/records.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/source-file-structure.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/structs.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/type-events.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/type-fields.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/type-methods.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/type-operators.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/corpus/type-properties.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/grammar.js
x diffsitter_src/grammars/tree-sitter-c-sharp/index.js
x diffsitter_src/grammars/tree-sitter-c-sharp/package.json
x diffsitter_src/grammars/tree-sitter-c-sharp/queries/
x diffsitter_src/grammars/tree-sitter-c-sharp/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-c-sharp/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-c-sharp/script/
x diffsitter_src/grammars/tree-sitter-c-sharp/script/fetch-examples
x diffsitter_src/grammars/tree-sitter-c-sharp/script/known-failures.txt
x diffsitter_src/grammars/tree-sitter-c-sharp/script/parse-examples
x diffsitter_src/grammars/tree-sitter-c-sharp/script/update-known-failures
x diffsitter_src/grammars/tree-sitter-c-sharp/src/
x diffsitter_src/grammars/tree-sitter-c-sharp/src/binding.cc
x diffsitter_src/grammars/tree-sitter-c-sharp/src/grammar.json
x diffsitter_src/grammars/tree-sitter-c-sharp/src/node-types.json
x diffsitter_src/grammars/tree-sitter-c-sharp/src/parser.c
x diffsitter_src/grammars/tree-sitter-c-sharp/src/scanner.c
x diffsitter_src/grammars/tree-sitter-c-sharp/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-c-sharp/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-c-sharp/test.js
x diffsitter_src/grammars/tree-sitter-c-sharp/test/
x diffsitter_src/grammars/tree-sitter-c-sharp/test/queries/
x diffsitter_src/grammars/tree-sitter-c-sharp/test/queries/identifiers.cs
x diffsitter_src/grammars/tree-sitter-python/
x diffsitter_src/grammars/tree-sitter-python/.gitattributes
x diffsitter_src/grammars/tree-sitter-python/.github/
x diffsitter_src/grammars/tree-sitter-python/.github/workflows/
x diffsitter_src/grammars/tree-sitter-python/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-python/.gitignore
x diffsitter_src/grammars/tree-sitter-python/.npmignore
x diffsitter_src/grammars/tree-sitter-python/LICENSE
x diffsitter_src/grammars/tree-sitter-python/README.md
x diffsitter_src/grammars/tree-sitter-python/binding.gyp
x diffsitter_src/grammars/tree-sitter-python/bindings/
x diffsitter_src/grammars/tree-sitter-python/bindings/node/
x diffsitter_src/grammars/tree-sitter-python/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-python/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-python/examples/
x diffsitter_src/grammars/tree-sitter-python/examples/compound-statement-without-trailing-newline.py
x diffsitter_src/grammars/tree-sitter-python/examples/crlf-line-endings.py
x diffsitter_src/grammars/tree-sitter-python/examples/mixed-spaces-tabs.py
x diffsitter_src/grammars/tree-sitter-python/examples/multiple-newlines.py
x diffsitter_src/grammars/tree-sitter-python/examples/python2-grammar-crlf.py
x diffsitter_src/grammars/tree-sitter-python/examples/python2-grammar.py
x diffsitter_src/grammars/tree-sitter-python/examples/python3-grammar-crlf.py
x diffsitter_src/grammars/tree-sitter-python/examples/python3-grammar.py
x diffsitter_src/grammars/tree-sitter-python/examples/python3.8_grammar.py
x diffsitter_src/grammars/tree-sitter-python/examples/simple-statements-without-trailing-newline.py
x diffsitter_src/grammars/tree-sitter-python/examples/tabs.py
x diffsitter_src/grammars/tree-sitter-python/examples/trailing-whitespace.py
x diffsitter_src/grammars/tree-sitter-python/grammar.js
x diffsitter_src/grammars/tree-sitter-python/package.json
x diffsitter_src/grammars/tree-sitter-python/queries/
x diffsitter_src/grammars/tree-sitter-python/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-python/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-python/script/
x diffsitter_src/grammars/tree-sitter-python/script/known_failures.txt
x diffsitter_src/grammars/tree-sitter-python/script/parse-examples
x diffsitter_src/grammars/tree-sitter-python/src/
x diffsitter_src/grammars/tree-sitter-python/src/grammar.json
x diffsitter_src/grammars/tree-sitter-python/src/node-types.json
x diffsitter_src/grammars/tree-sitter-python/src/parser.c
x diffsitter_src/grammars/tree-sitter-python/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-python/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-python/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-python/test/
x diffsitter_src/grammars/tree-sitter-python/test/corpus/
x diffsitter_src/grammars/tree-sitter-python/test/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-python/test/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-python/test/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-python/test/highlight/
x diffsitter_src/grammars/tree-sitter-python/test/highlight/keywords.py
x diffsitter_src/grammars/tree-sitter-java/
x diffsitter_src/grammars/tree-sitter-java/.gitattributes
x diffsitter_src/grammars/tree-sitter-java/.github/
x diffsitter_src/grammars/tree-sitter-java/.github/pull_request_template.md
x diffsitter_src/grammars/tree-sitter-java/.github/workflows/
x diffsitter_src/grammars/tree-sitter-java/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-java/.gitignore
x diffsitter_src/grammars/tree-sitter-java/.npmignore
x diffsitter_src/grammars/tree-sitter-java/CONTRIBUTING.md
x diffsitter_src/grammars/tree-sitter-java/LICENSE
x diffsitter_src/grammars/tree-sitter-java/README.md
x diffsitter_src/grammars/tree-sitter-java/binding.gyp
x diffsitter_src/grammars/tree-sitter-java/bindings/
x diffsitter_src/grammars/tree-sitter-java/bindings/node/
x diffsitter_src/grammars/tree-sitter-java/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-java/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-java/grammar.js
x diffsitter_src/grammars/tree-sitter-java/issue_template.md
x diffsitter_src/grammars/tree-sitter-java/package.json
x diffsitter_src/grammars/tree-sitter-java/queries/
x diffsitter_src/grammars/tree-sitter-java/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-java/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-java/script/
x diffsitter_src/grammars/tree-sitter-java/script/known-failures.txt
x diffsitter_src/grammars/tree-sitter-java/script/parse-examples
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/README.md
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/bootstrap
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/pom.xml
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/run
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/src/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/src/main/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/src/main/java/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/src/main/java/com/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/src/main/java/com/github/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/src/main/java/com/github/tree-sitter/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/src/main/java/com/github/tree-sitter/RunJavaParser.java
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/classes/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/classes/RunJavaParser.class
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-archiver/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-archiver/pom.properties
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-status/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-status/maven-compiler-plugin/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-status/maven-compiler-plugin/compile/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-status/maven-compiler-plugin/compile/default-compile/
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
x diffsitter_src/grammars/tree-sitter-java/script/run-javaparser/target/run-javaparser-1.0-SNAPSHOT.jar
x diffsitter_src/grammars/tree-sitter-java/src/
x diffsitter_src/grammars/tree-sitter-java/src/grammar.json
x diffsitter_src/grammars/tree-sitter-java/src/node-types.json
x diffsitter_src/grammars/tree-sitter-java/src/parser.c
x diffsitter_src/grammars/tree-sitter-java/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-java/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-java/test/
x diffsitter_src/grammars/tree-sitter-java/test/corpus/
x diffsitter_src/grammars/tree-sitter-java/test/corpus/comments.txt
x diffsitter_src/grammars/tree-sitter-java/test/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-java/test/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-java/test/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-java/test/corpus/precedence.txt
x diffsitter_src/grammars/tree-sitter-java/test/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-java/test/highlight/
x diffsitter_src/grammars/tree-sitter-java/test/highlight/types.java
x diffsitter_src/grammars/tree-sitter-ruby/
x diffsitter_src/grammars/tree-sitter-ruby/.gitattributes
x diffsitter_src/grammars/tree-sitter-ruby/.github/
x diffsitter_src/grammars/tree-sitter-ruby/.github/pull_request_template.md
x diffsitter_src/grammars/tree-sitter-ruby/.github/workflows/
x diffsitter_src/grammars/tree-sitter-ruby/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-ruby/.gitignore
x diffsitter_src/grammars/tree-sitter-ruby/.gitmodules
x diffsitter_src/grammars/tree-sitter-ruby/.npmignore
x diffsitter_src/grammars/tree-sitter-ruby/LICENSE
x diffsitter_src/grammars/tree-sitter-ruby/README.md
x diffsitter_src/grammars/tree-sitter-ruby/binding.gyp
x diffsitter_src/grammars/tree-sitter-ruby/bindings/
x diffsitter_src/grammars/tree-sitter-ruby/bindings/node/
x diffsitter_src/grammars/tree-sitter-ruby/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-ruby/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-ruby/grammar.js
x diffsitter_src/grammars/tree-sitter-ruby/package.json
x diffsitter_src/grammars/tree-sitter-ruby/queries/
x diffsitter_src/grammars/tree-sitter-ruby/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-ruby/queries/locals.scm
x diffsitter_src/grammars/tree-sitter-ruby/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-ruby/script/
x diffsitter_src/grammars/tree-sitter-ruby/script/known_failures.txt
x diffsitter_src/grammars/tree-sitter-ruby/script/parse-examples
x diffsitter_src/grammars/tree-sitter-ruby/src/
x diffsitter_src/grammars/tree-sitter-ruby/src/grammar.json
x diffsitter_src/grammars/tree-sitter-ruby/src/node-types.json
x diffsitter_src/grammars/tree-sitter-ruby/src/parser.c
x diffsitter_src/grammars/tree-sitter-ruby/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-ruby/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-ruby/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-ruby/test/
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/comments.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/control-flow.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/errors.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/line-endings.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/patterns.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/single-cr-as-whitespace.rb
x diffsitter_src/grammars/tree-sitter-ruby/test/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-ruby/test/highlight/
x diffsitter_src/grammars/tree-sitter-ruby/test/highlight/classes.rb
x diffsitter_src/grammars/tree-sitter-ruby/test/highlight/constants.rb
x diffsitter_src/grammars/tree-sitter-ruby/test/highlight/literals.rb
x diffsitter_src/grammars/tree-sitter-ruby/test/highlight/patterns.rb
x diffsitter_src/grammars/tree-sitter-ruby/test/highlight/variables.rb
x diffsitter_src/grammars/tree-sitter-hcl/
x diffsitter_src/grammars/tree-sitter-hcl/.envrc
x diffsitter_src/grammars/tree-sitter-hcl/.gitignore
x diffsitter_src/grammars/tree-sitter-hcl/LICENSE
x diffsitter_src/grammars/tree-sitter-hcl/README.md
x diffsitter_src/grammars/tree-sitter-hcl/binding.gyp
x diffsitter_src/grammars/tree-sitter-hcl/bindings/
x diffsitter_src/grammars/tree-sitter-hcl/bindings/node/
x diffsitter_src/grammars/tree-sitter-hcl/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-hcl/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-hcl/corpus/
x diffsitter_src/grammars/tree-sitter-hcl/corpus/attribute.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/block.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/collection.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/comment.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/conditional.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/for.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/function.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/huge.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/numeric.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/operation.txt
x diffsitter_src/grammars/tree-sitter-hcl/corpus/template.txt
x diffsitter_src/grammars/tree-sitter-hcl/flake.lock
x diffsitter_src/grammars/tree-sitter-hcl/flake.nix
x diffsitter_src/grammars/tree-sitter-hcl/grammar.js
x diffsitter_src/grammars/tree-sitter-hcl/package.json
x diffsitter_src/grammars/tree-sitter-hcl/project.nix
x diffsitter_src/grammars/tree-sitter-hcl/queries/
x diffsitter_src/grammars/tree-sitter-hcl/queries/folds.scm
x diffsitter_src/grammars/tree-sitter-hcl/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-hcl/shell.nix
x diffsitter_src/grammars/tree-sitter-hcl/src/
x diffsitter_src/grammars/tree-sitter-hcl/src/grammar.json
x diffsitter_src/grammars/tree-sitter-hcl/src/node-types.json
x diffsitter_src/grammars/tree-sitter-hcl/src/parser.c
x diffsitter_src/grammars/tree-sitter-hcl/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-hcl/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-hcl/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-bash/
x diffsitter_src/grammars/tree-sitter-bash/.gitattributes
x diffsitter_src/grammars/tree-sitter-bash/.github/
x diffsitter_src/grammars/tree-sitter-bash/.github/workflows/
x diffsitter_src/grammars/tree-sitter-bash/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-bash/.gitignore
x diffsitter_src/grammars/tree-sitter-bash/.gitmodules
x diffsitter_src/grammars/tree-sitter-bash/.npmignore
x diffsitter_src/grammars/tree-sitter-bash/.travis.yml
x diffsitter_src/grammars/tree-sitter-bash/LICENSE
x diffsitter_src/grammars/tree-sitter-bash/README.md
x diffsitter_src/grammars/tree-sitter-bash/appveyor.yml
x diffsitter_src/grammars/tree-sitter-bash/binding.gyp
x diffsitter_src/grammars/tree-sitter-bash/bindings/
x diffsitter_src/grammars/tree-sitter-bash/bindings/node/
x diffsitter_src/grammars/tree-sitter-bash/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-bash/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-bash/corpus/
x diffsitter_src/grammars/tree-sitter-bash/corpus/commands.txt
x diffsitter_src/grammars/tree-sitter-bash/corpus/crlf.txt
x diffsitter_src/grammars/tree-sitter-bash/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-bash/corpus/programs.txt
x diffsitter_src/grammars/tree-sitter-bash/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-bash/examples/
x diffsitter_src/grammars/tree-sitter-bash/examples/atom.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/
x diffsitter_src/grammars/tree-sitter-bash/examples/clean-old.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/doc-build.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/install.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/release.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/relocate.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/test.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/update-authors.sh
x diffsitter_src/grammars/tree-sitter-bash/grammar.js
x diffsitter_src/grammars/tree-sitter-bash/package.json
x diffsitter_src/grammars/tree-sitter-bash/queries/
x diffsitter_src/grammars/tree-sitter-bash/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-bash/script/
x diffsitter_src/grammars/tree-sitter-bash/script/known-failures.txt
x diffsitter_src/grammars/tree-sitter-bash/script/parse-examples.sh
x diffsitter_src/grammars/tree-sitter-bash/script/update-known-failures.sh
x diffsitter_src/grammars/tree-sitter-bash/src/
x diffsitter_src/grammars/tree-sitter-bash/src/grammar.json
x diffsitter_src/grammars/tree-sitter-bash/src/node-types.json
x diffsitter_src/grammars/tree-sitter-bash/src/parser.c
x diffsitter_src/grammars/tree-sitter-bash/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-bash/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-bash/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/.ackrc
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/.editorconfig
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/.gitattributes
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/.gitignore
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/.gitmodules
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/.travis.yml
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/CONTRIBUTING.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/DEVELOPMENT.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/ag.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/ansible.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/apt.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/atom.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/bundler.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/clipboard.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/curl.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/docker-compose.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/docker.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/emacs.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/fuck.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/general.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/git.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/gitsvn.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/heroku.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/hg.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/homebrew-cask.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/homebrew.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/homesick.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/jitsu.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/laravel.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/maven.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/npm.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/osx.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/phoenix.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/pyrocms.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/rails.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/svn.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/systemd.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/textmate.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/tmux.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/todo.txt-cli.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/vagrant.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/vault.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/vim.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/aliases/available/yarn.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/bash_it.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/apm.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/awless.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/awscli.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/bash-it.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/brew.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/bundler.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/capistrano.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/composer.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/conda.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/defaults.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/dirs.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/django.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/docker-compose.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/docker-machine.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/docker.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/drush.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/export.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/fabric-completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/gem.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/gh.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/git.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/git_flow.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/git_flow_avh.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/go.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/gradle.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/grunt.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/gulp.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/homesick.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/hub.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/invoke.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/jboss7.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/jungle.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/kontena.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/kubectl.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/makefile.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/maven.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/ng.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/npm.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/nvm.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/openshift.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/packer.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/pew.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/pip.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/pip3.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/pipenv.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/projects.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/rake.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/rvm.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/salt.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/sdkman.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/ssh.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/svn.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/system.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/terraform.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/test_kitchen.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/tmux.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/todo.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/travis.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/vagrant.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/vault.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/virsh.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/completion/available/virtualbox.completion.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/custom/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/custom/example.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/install.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/appearance.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/composure.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/helpers.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/history.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/preexec.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/preview.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/lib/search.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/alias-completion.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/autojump.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/aws.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/base.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/battery.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/boot2docker.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/browser.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/chruby-auto.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/chruby.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/direnv.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/dirs.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/docker-compose.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/docker-machine.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/docker.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/edit-mode-emacs.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/edit-mode-vi.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/explain.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/extract.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/fasd.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/fzf.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/gh.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/gif.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/git-subrepo.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/git.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/go.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/gradle.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/hg.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/history.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/hub.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/java.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/javascript.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/jekyll.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/jenv.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/latex.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/less-pretty-cat.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/nginx.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/node.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/nvm.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/osx-timemachine.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/osx.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/percol.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/pipsi.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/plenv.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/postgres.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/projects.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/proxy.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/pyenv.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/python.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/rails.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/rbenv.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/ruby.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/rvm.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/sdkman.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/ssh.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/sshagent.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/subversion.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/textmate.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/tmux.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/tmuxinator.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/todo.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/virtualenv.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/visual-studio-code.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/xterm.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/z.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/plugins/available/z_autoenv.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/template/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/template/bash_profile.template.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/bash_it/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/bash_it/bash_it.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/completion/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/completion/bash-it.completion.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/aliases/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/aliases/available/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/aliases/available/a.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/aliases/available/b.aliases.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/plugins/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/plugins/available/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/fixtures/bash_it/plugins/available/c.plugin.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/install/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/install/install.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/install/uninstall.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/lib/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/lib/composure.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/lib/helpers.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/lib/search.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/plugins/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/plugins/base.plugin.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/plugins/battery.plugin.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/plugins/ruby.plugin.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/run
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/test_helper.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/themes/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/themes/base.theme.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test/themes/base.theme.git.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/90210/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/90210/90210.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/atomic/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/atomic/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/atomic/atomic.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/axin/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/axin/axin.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/bakke/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/bakke/bakke.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/base.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/binaryanomaly/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/binaryanomaly/binaryanomaly.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/bobby-python/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/bobby-python/bobby-python.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/bobby/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/bobby/bobby.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/brainy/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/brainy/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/brainy/brainy.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/brunton/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/brunton/brunton.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/candy/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/candy/candy.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/clean/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/clean/clean.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/colors.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/cooperkid/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/cooperkid/cooperkid.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/cupcake/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/cupcake/cupcake.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/demula/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/demula/demula.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/dos/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/dos/dos.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/doubletime/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/doubletime/doubletime.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/doubletime_multiline/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/doubletime_multiline/doubletime_multiline.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/doubletime_multiline_pyonly/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/doubletime_multiline_pyonly/doubletime_multiline_pyonly.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/dulcie/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/dulcie/dulcie.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/duru/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/duru/duru.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/emperor/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/emperor/emperor.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/envy/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/envy/envy.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/font/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/font/font.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/gallifrey/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/gallifrey/gallifrey.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/githelpers.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/hawaii50/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/hawaii50/hawaii50.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/iterate/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/iterate/iterate.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/kitsune/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/kitsune/kitsune.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/liquidprompt/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/liquidprompt/.gitignore
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/liquidprompt/liquidprompt.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/luan/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/luan/luan.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/mairan/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/mairan/mairan.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/mbriggs/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/mbriggs/mbriggs.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/minimal/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/minimal/minimal.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/modern-t/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/modern-t/modern-t.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/modern/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/modern/modern.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/morris/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/morris/morris.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/n0qorg/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/n0qorg/n0qorg.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler/nwinkler.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler_random_colors/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler_random_colors/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler_random_colors/nwinkler_random_colors.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/nwinkler_random_colors/screenshot.png
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/p4helpers.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/pete/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/pete/pete.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-multiline/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-multiline/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-multiline/powerline-multiline.base.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-multiline/powerline-multiline.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-naked/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-naked/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-naked/powerline-naked.base.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-naked/powerline-naked.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-plain/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-plain/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-plain/powerline-plain.base.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline-plain/powerline-plain.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline/powerline.base.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/powerline/powerline.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/primer/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/primer/primer.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/pro/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/pro/pro.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/pure/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/pure/pure.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/purity/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/purity/purity.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/rainbowbrite/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/rainbowbrite/rainbowbrite.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/rana/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/rana/rana.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/redline/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/redline/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/redline/redline.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/redline/screenshot.png
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/rjorgenson/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/rjorgenson/rjorgenson.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/roderik/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/roderik/roderik.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/sexy/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/sexy/sexy.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/simple/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/simple/simple.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/sirup/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/sirup/sirup.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/slick/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/slick/slick.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/standard/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/standard/standard.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/tonka/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/tonka/tonka.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/tonotdo/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/tonotdo/tonotdo.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/tylenol/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/tylenol/tylenol.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/wanelo/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/wanelo/wanelo.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/zitron/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/zitron/zitron.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/zork/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/themes/zork/zork.theme.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/uninstall.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/.travis.yml
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/CHANGELOG.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/LICENSE
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/load.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/package.json
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/script/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/script/install-bats.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/src/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/src/assert.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-11-assert.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-12-assert_equal.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-13-assert_success.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-14-assert_failure.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-15-assert_output.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-16-refute_output.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-17-assert_line.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-18-refute_line.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/50-assert-19-refute.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-assert/test/test_helper.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/.travis.yml
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/CHANGELOG.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/LICENSE
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/load.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/package.json
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/script/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/script/install-bats.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/src/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/src/error.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/src/lang.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/src/output.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-10-batslib_err.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-11-batslib_count_lines.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-12-batslib_is_single_line.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-13-batslib_get_max_single_line_key_width.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-14-batslib_print_kv_single.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-15-batslib_print_kv_multi.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-16-batslib_print_kv_single_or_multi.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-17-batslib_prefix.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-18-batslib_mark.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/50-output-19-batslib_decorate.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/51-error-10-fail.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/52-lang-10-batslib_is_caller.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-support/test/test_helper.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/.travis.yml
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/CHANGELOG.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/LICENSE
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/load.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/package.json
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/script/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/script/install-bats.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/src/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/src/file.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/src/temp.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/50-assert-10-assert_file_exist.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/50-assert-11-assert_file_not_exist.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/51-temp-10-temp_make.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/51-temp-11-temp_del.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/exist/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/exist/dir/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/exist/dir/file
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_del-fail.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_del-main.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_del-pass.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_del-setup.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_del-skip.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_del-teardown.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_del-test.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_make-main.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_make-setup.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_make-teardown.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/temp_make-test.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/fixtures/temp/test_helper.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-file/test/test_helper.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/.appveyor.yml
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/.gitattributes
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/.travis.yml
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/CONDUCT.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/LICENSE
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/bin/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/bin/bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/install.sh
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-exec-suite
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-exec-test
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-format-tap-stream
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/libexec/bats-preprocess
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/Makefile
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/README.md
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.1
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.1.ronn
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.7
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/man/bats.7.ronn
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/package.json
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/bats.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/dos_line.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/empty.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/environment.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/expand_var_in_test_name.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/failing.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/failing_and_passing.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/failing_helper.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/failing_setup.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/failing_teardown.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/intact.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/invalid_tap.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/load.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/loop_keep_IFS.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/output.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/passing.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/passing_and_failing.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/passing_and_skipping.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/passing_failing_and_skipping.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/quoted_and_unquoted_test_names.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/setup.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/single_line.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/skipped.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/teardown.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/test_helper.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/bats/without_trailing_newline.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/empty/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/empty/.gitkeep
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/multiple/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/multiple/a.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/multiple/b.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/single/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/fixtures/suite/single/test.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/suite.bats
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/test_helper.bash
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/tmp/
x diffsitter_src/grammars/tree-sitter-bash/examples/bash-it/test_lib/bats-core/test/tmp/.gitignore
x diffsitter_src/grammars/tree-sitter-cpp/
x diffsitter_src/grammars/tree-sitter-cpp/.appveyor.yml
x diffsitter_src/grammars/tree-sitter-cpp/.gitattributes
x diffsitter_src/grammars/tree-sitter-cpp/.gitignore
x diffsitter_src/grammars/tree-sitter-cpp/.npmignore
x diffsitter_src/grammars/tree-sitter-cpp/.travis.yml
x diffsitter_src/grammars/tree-sitter-cpp/LICENSE
x diffsitter_src/grammars/tree-sitter-cpp/README.md
x diffsitter_src/grammars/tree-sitter-cpp/binding.gyp
x diffsitter_src/grammars/tree-sitter-cpp/bindings/
x diffsitter_src/grammars/tree-sitter-cpp/bindings/node/
x diffsitter_src/grammars/tree-sitter-cpp/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-cpp/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-cpp/examples/
x diffsitter_src/grammars/tree-sitter-cpp/examples/marker-index.h
x diffsitter_src/grammars/tree-sitter-cpp/examples/rule.cc
x diffsitter_src/grammars/tree-sitter-cpp/grammar.js
x diffsitter_src/grammars/tree-sitter-cpp/package.json
x diffsitter_src/grammars/tree-sitter-cpp/queries/
x diffsitter_src/grammars/tree-sitter-cpp/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-cpp/src/
x diffsitter_src/grammars/tree-sitter-cpp/src/grammar.json
x diffsitter_src/grammars/tree-sitter-cpp/src/node-types.json
x diffsitter_src/grammars/tree-sitter-cpp/src/parser.c
x diffsitter_src/grammars/tree-sitter-cpp/src/scanner.cc
x diffsitter_src/grammars/tree-sitter-cpp/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-cpp/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-cpp/src/tree_sitter/runtime.h
x diffsitter_src/grammars/tree-sitter-cpp/test/
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/ambiguities.txt
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/definitions.txt
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/microsoft.txt
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/statements.txt
x diffsitter_src/grammars/tree-sitter-cpp/test/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-cpp/test/highlight/
x diffsitter_src/grammars/tree-sitter-cpp/test/highlight/keywords.cpp
x diffsitter_src/grammars/tree-sitter-cpp/test/highlight/names.cpp
x diffsitter_src/grammars/tree-sitter-rust/
x diffsitter_src/grammars/tree-sitter-rust/.gitattributes
x diffsitter_src/grammars/tree-sitter-rust/.github/
x diffsitter_src/grammars/tree-sitter-rust/.github/workflows/
x diffsitter_src/grammars/tree-sitter-rust/.github/workflows/ci.yml
x diffsitter_src/grammars/tree-sitter-rust/.gitignore
x diffsitter_src/grammars/tree-sitter-rust/.gitmodules
x diffsitter_src/grammars/tree-sitter-rust/.npmignore
x diffsitter_src/grammars/tree-sitter-rust/LICENSE
x diffsitter_src/grammars/tree-sitter-rust/README.md
x diffsitter_src/grammars/tree-sitter-rust/binding.gyp
x diffsitter_src/grammars/tree-sitter-rust/bindings/
x diffsitter_src/grammars/tree-sitter-rust/bindings/node/
x diffsitter_src/grammars/tree-sitter-rust/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-rust/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-rust/corpus/
x diffsitter_src/grammars/tree-sitter-rust/corpus/async.txt
x diffsitter_src/grammars/tree-sitter-rust/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-rust/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-rust/corpus/literals.txt
x diffsitter_src/grammars/tree-sitter-rust/corpus/macros.txt
x diffsitter_src/grammars/tree-sitter-rust/corpus/patterns.txt
x diffsitter_src/grammars/tree-sitter-rust/corpus/source_files.txt
x diffsitter_src/grammars/tree-sitter-rust/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-rust/examples/
x diffsitter_src/grammars/tree-sitter-rust/examples/ast.rs
x diffsitter_src/grammars/tree-sitter-rust/grammar.js
x diffsitter_src/grammars/tree-sitter-rust/package.json
x diffsitter_src/grammars/tree-sitter-rust/queries/
x diffsitter_src/grammars/tree-sitter-rust/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-rust/queries/injections.scm
x diffsitter_src/grammars/tree-sitter-rust/script/
x diffsitter_src/grammars/tree-sitter-rust/script/fetch-examples
x diffsitter_src/grammars/tree-sitter-rust/script/known_failures.txt
x diffsitter_src/grammars/tree-sitter-rust/script/parse-examples
x diffsitter_src/grammars/tree-sitter-rust/script/rustc-parse
x diffsitter_src/grammars/tree-sitter-rust/src/
x diffsitter_src/grammars/tree-sitter-rust/src/grammar.json
x diffsitter_src/grammars/tree-sitter-rust/src/node-types.json
x diffsitter_src/grammars/tree-sitter-rust/src/parser.c
x diffsitter_src/grammars/tree-sitter-rust/src/scanner.c
x diffsitter_src/grammars/tree-sitter-rust/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-rust/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-typescript/
x diffsitter_src/grammars/tree-sitter-typescript/.gitattributes
x diffsitter_src/grammars/tree-sitter-typescript/.github/
x diffsitter_src/grammars/tree-sitter-typescript/.github/ISSUE_TEMPLATE/
x diffsitter_src/grammars/tree-sitter-typescript/.github/ISSUE_TEMPLATE/bug_report.md
x diffsitter_src/grammars/tree-sitter-typescript/.github/ISSUE_TEMPLATE/feature_request.md
x diffsitter_src/grammars/tree-sitter-typescript/.github/pull_request_template.md
x diffsitter_src/grammars/tree-sitter-typescript/.github/workflows/
x diffsitter_src/grammars/tree-sitter-typescript/.github/workflows/build.yml
x diffsitter_src/grammars/tree-sitter-typescript/.gitignore
x diffsitter_src/grammars/tree-sitter-typescript/.npmignore
x diffsitter_src/grammars/tree-sitter-typescript/LICENSE
x diffsitter_src/grammars/tree-sitter-typescript/README.md
x diffsitter_src/grammars/tree-sitter-typescript/appveyor.yml
x diffsitter_src/grammars/tree-sitter-typescript/binding.gyp
x diffsitter_src/grammars/tree-sitter-typescript/bindings/
x diffsitter_src/grammars/tree-sitter-typescript/bindings/node/
x diffsitter_src/grammars/tree-sitter-typescript/bindings/node/binding.cc
x diffsitter_src/grammars/tree-sitter-typescript/bindings/node/index.js
x diffsitter_src/grammars/tree-sitter-typescript/bindings/node/tsx.js
x diffsitter_src/grammars/tree-sitter-typescript/bindings/node/typescript.js
x diffsitter_src/grammars/tree-sitter-typescript/common/
x diffsitter_src/grammars/tree-sitter-typescript/common/corpus/
x diffsitter_src/grammars/tree-sitter-typescript/common/corpus/declarations.txt
x diffsitter_src/grammars/tree-sitter-typescript/common/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-typescript/common/corpus/functions.txt
x diffsitter_src/grammars/tree-sitter-typescript/common/corpus/types.txt
x diffsitter_src/grammars/tree-sitter-typescript/common/define-grammar.js
x diffsitter_src/grammars/tree-sitter-typescript/common/scanner.h
x diffsitter_src/grammars/tree-sitter-typescript/examples/
x diffsitter_src/grammars/tree-sitter-typescript/examples/parser.ts
x diffsitter_src/grammars/tree-sitter-typescript/package.json
x diffsitter_src/grammars/tree-sitter-typescript/queries/
x diffsitter_src/grammars/tree-sitter-typescript/queries/highlights.scm
x diffsitter_src/grammars/tree-sitter-typescript/queries/locals.scm
x diffsitter_src/grammars/tree-sitter-typescript/queries/tags.scm
x diffsitter_src/grammars/tree-sitter-typescript/script/
x diffsitter_src/grammars/tree-sitter-typescript/script/check-generated-files
x diffsitter_src/grammars/tree-sitter-typescript/script/known-failures.txt
x diffsitter_src/grammars/tree-sitter-typescript/script/parse-examples
x diffsitter_src/grammars/tree-sitter-typescript/tsx/
x diffsitter_src/grammars/tree-sitter-typescript/tsx/corpus/
x diffsitter_src/grammars/tree-sitter-typescript/tsx/corpus/common
x diffsitter_src/grammars/tree-sitter-typescript/tsx/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-typescript/tsx/grammar.js
x diffsitter_src/grammars/tree-sitter-typescript/tsx/package.json
x diffsitter_src/grammars/tree-sitter-typescript/tsx/src/
x diffsitter_src/grammars/tree-sitter-typescript/tsx/src/grammar.json
x diffsitter_src/grammars/tree-sitter-typescript/tsx/src/node-types.json
x diffsitter_src/grammars/tree-sitter-typescript/tsx/src/parser.c
x diffsitter_src/grammars/tree-sitter-typescript/tsx/src/scanner.c
x diffsitter_src/grammars/tree-sitter-typescript/tsx/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-typescript/tsx/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-typescript/typescript/
x diffsitter_src/grammars/tree-sitter-typescript/typescript/corpus/
x diffsitter_src/grammars/tree-sitter-typescript/typescript/corpus/common
x diffsitter_src/grammars/tree-sitter-typescript/typescript/corpus/expressions.txt
x diffsitter_src/grammars/tree-sitter-typescript/typescript/grammar.js
x diffsitter_src/grammars/tree-sitter-typescript/typescript/package.json
x diffsitter_src/grammars/tree-sitter-typescript/typescript/src/
x diffsitter_src/grammars/tree-sitter-typescript/typescript/src/grammar.json
x diffsitter_src/grammars/tree-sitter-typescript/typescript/src/node-types.json
x diffsitter_src/grammars/tree-sitter-typescript/typescript/src/parser.c
x diffsitter_src/grammars/tree-sitter-typescript/typescript/src/scanner.c
x diffsitter_src/grammars/tree-sitter-typescript/typescript/src/tree_sitter/
x diffsitter_src/grammars/tree-sitter-typescript/typescript/src/tree_sitter/parser.h
x diffsitter_src/grammars/tree-sitter-typescript/typescript/test.ts
x diffsitter_src/grammars/tree-sitter-typescript/yarn.lock
```
</details>