### PR TITLE
fix: Address pedantic clippy lints

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -374,7 +374,7 @@ use phf::phf_map;
         // will cache based on the Rust modules and isn't aware of the linked C libraries.
         for source in params.c_sources.iter().chain(params.cpp_sources.iter()) {
             if let Some(grammar_path) = &source.as_path().to_str() {
-                rerun_if_changed!(grammar_path.to_string());
+                rerun_if_changed!((*grammar_path).to_string());
             } else {
                 bail!("Path to grammar for {} is not a valid string", language);
             }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -683,9 +683,9 @@ mod tests {
         let input_b = &b"CBABAC"[..];
         let mut frontiers = MyersFrontiers::new(input_a.len(), input_b.len());
         let mid_snake = Myers::middle_snake(
-            &input_a[..],
+            input_a,
             0..input_a.len(),
-            &input_b[..],
+            input_b,
             0..input_b.len(),
             &mut frontiers,
         );
@@ -756,12 +756,12 @@ mod tests {
     #[test_case(b"BAAA", b"CAAA" => 0 ; "no common prefix")]
     #[test_case(b"AAABA", b"AAACA" => 3 ; "with common prefix")]
     fn common_prefix(a: &[u8], b: &[u8]) -> usize {
-        common_prefix_len(&a[..], 0..a.len(), &b[..], 0..b.len())
+        common_prefix_len(a, 0..a.len(), b, 0..b.len())
     }
 
     #[test_case(b"AAAB", b"AAAC" => 0 ; "no common suffix")]
     #[test_case(b"ABAAA", b"ACAAA" => 3 ; "with common suffix")]
     fn common_suffix(a: &[u8], b: &[u8]) -> usize {
-        common_suffix_len(&a[..], 0..a.len(), &b[..], 0..b.len())
+        common_suffix_len(a, 0..a.len(), b, 0..b.len())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,8 +161,8 @@ fn run_diff(args: &Args, config: &Config) -> Result<()> {
     // AstVectorData structs. Because of that, we can't make a function that generates the ast
     // vectors in one shot.
 
-    let ast_data_a = generate_ast_vector_data(path_a.to_path_buf(), file_type, &config.grammar)?;
-    let ast_data_b = generate_ast_vector_data(path_b.to_path_buf(), file_type, &config.grammar)?;
+    let ast_data_a = generate_ast_vector_data(path_a.clone(), file_type, &config.grammar)?;
+    let ast_data_b = generate_ast_vector_data(path_b.clone(), file_type, &config.grammar)?;
 
     let diff_vec_a = generate_ast_vector(&ast_data_a);
     let diff_vec_b = generate_ast_vector(&ast_data_b);
@@ -294,8 +294,8 @@ mod tests {
     fn diff_hunks_snapshot(test_type: &str, name: &str, ext: &str) {
         let (path_a, path_b) = get_test_paths(test_type, name, ext);
         let config = GrammarConfig::default();
-        let ast_data_a = generate_ast_vector_data(path_a.to_path_buf(), None, &config).unwrap();
-        let ast_data_b = generate_ast_vector_data(path_b.to_path_buf(), None, &config).unwrap();
+        let ast_data_a = generate_ast_vector_data(path_a, None, &config).unwrap();
+        let ast_data_b = generate_ast_vector_data(path_b, None, &config).unwrap();
         let diff_vec_a = generate_ast_vector(&ast_data_a);
         let diff_vec_b = generate_ast_vector(&ast_data_b);
         let diff_hunks = ast::compute_edit_script(&diff_vec_a, &diff_vec_b);


### PR DESCRIPTION
These fixes were automatically generated with:

```sh
cargo clippy --fix -- -W clippy::pedantic
```
