### PR TITLE
fix: Remove unneeded test annotation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,6 @@ mod tests {
 
     #[test_case("short", "rust", "rs")]
     #[test_case("short", "python", "py")]
-    #[test]
     fn diff_hunks_snapshot(test_type: &str, name: &str, ext: &str) {
         let (path_a, path_b) = get_test_paths(test_type, name, ext);
         let config = GrammarConfig::default();


### PR DESCRIPTION
The `#[test]` annotation is redundant with the `#[test_case]` annotation
and causes threading issues and causes two instances of the same test to
be run, which was causing some intermittent issues when test cases would
read/write to the same snapshot file and trigger a failure.
