### PR TITLE
chore: Migrate from structop to clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -243,17 +234,34 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
- "ansi_term 0.11.0",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
+ "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
+ "unicase",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -359,6 +367,7 @@ dependencies = [
  "build-info-build",
  "cargo-emit",
  "cc",
+ "clap",
  "console",
  "directories-next",
  "insta",
@@ -374,7 +383,6 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "structopt",
  "strum",
  "strum_macros",
  "test-case",
@@ -545,6 +553,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -820,6 +834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,7 +989,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
@@ -978,7 +1001,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d5b548b725018ab5496482b45cb8bef21e9fed1858a6d674e3a8a0f0bb5d50"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
@@ -1282,34 +1305,9 @@ checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "paw",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -1323,7 +1321,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1375,10 +1373,11 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
+ "terminal_size",
  "unicode-width",
 ]
 
@@ -1450,6 +1449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,12 +1507,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,12 @@ include = [
 
 [dependencies]
 tree-sitter = "0.20.4"
-structopt = { version = "0.3.26", features = ["paw"] }
+clap = { version = "3.0.14", features = [
+  "derive",
+  "env",
+  "unicode",
+  "wrap_help",
+] }
 anyhow = "1.0.53"
 phf = { version = "0.10.1", features = ["macros"] }
 console = "0.15.0"

--- a/build.rs
+++ b/build.rs
@@ -397,5 +397,7 @@ fn main() -> Result<()> {
 
     #[cfg(feature = "better-build-info")]
     build_info_build::build_script();
+
+    // TODO(afnan): add generaetd shell completion scripts
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,28 +1,15 @@
-//! Code related to the CLI
-
-#[cfg(feature = "static-grammar-libs")]
-use crate::parse::supported_languages;
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use strum_macros::{Display, EnumString};
 
-#[derive(Debug, Eq, PartialEq, Clone, StructOpt)]
-#[structopt(
-    name = "diffsitter",
-    about = "AST based diffs",
-    settings = &[
-        structopt::clap::AppSettings::ColoredHelp,
-        structopt::clap::AppSettings::ColorAuto,
-        structopt::clap::AppSettings::GlobalVersion,
-        structopt::clap::AppSettings::InferSubcommands,
-    ]
-)]
+#[derive(Debug, Eq, PartialEq, Clone, Parser)]
+#[clap(author, version, about)]
 pub struct Args {
     /// Print debug output
     ///
     /// This will print debug logs at the trace level. This is useful for debugging and bug reports
     /// should contain debug logging info.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub debug: bool,
     /// Run a subcommand that doesn't perform a diff. Valid options are: "list",
     /// "dump_default_config", and "build_info".
@@ -33,56 +20,51 @@ pub struct Args {
     /// * "dump_default_config" will dump the default configuration to stdout
     ///
     /// * "build_info" prints extended build information
-    #[structopt(long)]
+    #[clap(subcommand)]
     pub cmd: Option<Command>,
     /// The first file to compare against
     ///
     /// Text that is in this file but is not in the new file is considered a deletion
-    #[structopt(name = "OLD", parse(from_os_str), required_unless = "cmd")]
+    // #[clap(name = "OLD", parse(from_os_str), required_unless_present = "cmd")]
+    #[clap(name = "OLD", parse(from_os_str))]
     pub old: Option<PathBuf>,
     /// The file that the old file is compared against
     ///
     /// Text that is in this file but is not in the old file is considered an addition
-    #[structopt(name = "NEW", parse(from_os_str), required_unless = "cmd")]
+    // #[clap(name = "NEW", parse(from_os_str), required_unless_present = "cmd")]
+    #[clap(name = "NEW", parse(from_os_str))]
     pub new: Option<PathBuf>,
     /// Manually set the file type for the given files
     ///
     /// This will dictate which parser is used with the difftool. You can list all of the valid
     /// file type strings with `diffsitter --cmd list`
-    #[structopt(short = "t", long)]
+    #[clap(short = 't', long)]
     pub file_type: Option<String>,
     /// Use the config provided at the given path
     ///
     /// By default, diffsitter attempts to find the config at `$XDG_CONFIG_HOME/diffsitter.json5`.
     /// On Windows the app will look in the standard config path.
-    #[structopt(short, long, env = "DIFFSITTER_CONFIG")]
+    // #[clap(short, long, env = "DIFFSITTER_CONFIG")]
+    #[clap(short, long)]
     pub config: Option<PathBuf>,
     /// Set the color output policy. Valid values are: "auto", "on", "off".
     ///
     /// "auto" will automatically detect whether colors should be applied by trying to determine
     /// whether the process is outputting to a TTY. "on" will enable output and "off" will
     /// disable color output regardless of whether the process detects a TTY.
-    #[structopt(long = "color", default_value)]
+    #[clap(long = "color", default_value_t)]
     pub color_output: ColorOutputPolicy,
     /// Ignore any config files and use the default config
     ///
     /// This will cause the app to ignore any configs and all config values will use the their
     /// default settings.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub no_config: bool,
 }
 
 /// Commands related to the configuration
-#[derive(Debug, Eq, PartialEq, Clone, Copy, StructOpt, EnumString)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Parser, EnumString)]
 #[strum(serialize_all = "snake_case")]
-#[structopt(
-    settings = &[
-        structopt::clap::AppSettings::ColoredHelp,
-        structopt::clap::AppSettings::ColorAuto,
-        structopt::clap::AppSettings::GlobalVersion,
-        structopt::clap::AppSettings::InferSubcommands,
-    ]
-)]
 pub enum Command {
     /// List the languages that this program was compiled for
     List,
@@ -93,24 +75,6 @@ pub enum Command {
     /// Print extended build information
     #[cfg(feature = "better-build-info")]
     BuildInfo,
-}
-
-/// Print a list of the languages that this instance of diffsitter was compiled with
-pub fn list_supported_languages() {
-    #[cfg(feature = "static-grammar-libs")]
-    {
-        let languages = supported_languages();
-        println!("This program was compiled with support for:");
-
-        for language in languages {
-            println!("- {}", language);
-        }
-    }
-
-    #[cfg(feature = "dynamic-grammar-libs")]
-    {
-        println!("This program will dynamically load grammars from shared libraries");
-    }
 }
 
 /// Whether the output to the terminal should be colored
@@ -129,15 +93,4 @@ impl Default for ColorOutputPolicy {
     fn default() -> Self {
         ColorOutputPolicy::Auto
     }
-}
-
-/// Set whether the terminal should display colors based on the user's preferences
-///
-/// This method will set the terminal output policy *for the current thread*.
-pub fn set_term_colors(color_opt: ColorOutputPolicy) {
-    match color_opt {
-        ColorOutputPolicy::Off => (console::set_colors_enabled(false)),
-        ColorOutputPolicy::On => (console::set_colors_enabled(true)),
-        _ => (),
-    };
 }


### PR DESCRIPTION
`structopt` is now in maintenance mode, and clap v3 has integrated the
struct derive bits from the deprecated library. This PR migrates from
`structopt` to `clap` and flattens the subcommands so they don't require
the `--cmd` flag anymore.
