### PR TITLE
fix: Update lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",


### PR DESCRIPTION
Dependencies were updated without updating the lockfile, which breaks
the release process. This updates the lock file to mitigate.
