### PR TITLE
feat: Generate shell completion scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678db4c39c013cc68b54d372bce2efc58e30a0337c497c9032fd196802df3bc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +377,7 @@ dependencies = [
  "cargo-emit",
  "cc",
  "clap",
+ "clap_complete",
  "console",
  "directories-next",
  "insta",
@@ -1314,6 +1324,9 @@ name = "strum"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,12 @@ clap = { version = "3.0.14", features = [
   "unicode",
   "wrap_help",
 ] }
+clap_complete = "3.0.5"
 anyhow = "1.0.53"
 phf = { version = "0.10.1", features = ["macros"] }
 console = "0.15.0"
 paw = "1.0.0"
-strum = "0.23.0"
+strum = { version = "0.23.0", features = ["derive"] }
 strum_macros = "0.23.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,42 @@ pub struct Args {
     pub no_config: bool,
 }
 
+/// A wrapper struct for `clap_complete::Shell`.
+///
+/// We need this wrapper so we can automatically serialize strings using `EnumString` and use the
+/// enums as a clap argument.
+#[derive(Copy, Clone, EnumString, PartialEq, Eq, Debug)]
+#[strum(serialize_all = "snake_case")]
+pub enum ShellWrapper {
+    Bash,
+    Zsh,
+    Fish,
+    Elvish,
+
+    #[strum(serialize = "powershell")]
+    PowerShell,
+}
+
+impl Default for ShellWrapper {
+    fn default() -> Self {
+        Self::Bash
+    }
+}
+
+impl From<ShellWrapper> for clap_complete::Shell {
+    fn from(wrapper: ShellWrapper) -> Self {
+        use clap_complete as cc;
+
+        match wrapper {
+            ShellWrapper::Bash => cc::Shell::Bash,
+            ShellWrapper::Zsh => cc::Shell::Zsh,
+            ShellWrapper::Fish => cc::Shell::Fish,
+            ShellWrapper::Elvish => cc::Shell::Elvish,
+            ShellWrapper::PowerShell => cc::Shell::PowerShell,
+        }
+    }
+}
+
 /// Commands related to the configuration
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Parser, EnumString)]
 #[strum(serialize_all = "snake_case")]
@@ -75,6 +111,14 @@ pub enum Command {
     /// Print extended build information
     #[cfg(feature = "better-build-info")]
     BuildInfo,
+
+    /// Generate shell completion scripts for diffsitter
+    GenCompletion {
+        /// The shell to generate completion scripts for.
+        ///
+        /// This will print the shell completion script to stdout. bash, zsh, and fish are supported.
+        shell: ShellWrapper,
+    },
 }
 
 /// Whether the output to the terminal should be colored

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod parse;
 use crate::parse::supported_languages;
 use anyhow::Result;
 use ast::{AstVector, AstVectorData};
+use clap::IntoApp;
 use clap::Parser;
 use cli::{Args, ColorOutputPolicy};
 use config::{Config, ConfigReadError};
@@ -248,6 +249,14 @@ fn set_term_colors(color_opt: ColorOutputPolicy) {
     };
 }
 
+/// Print shell completion scripts to `stdout`.
+///
+/// This is a basic wrapper for the subcommand.
+fn print_shell_completion(shell: clap_complete::Shell) {
+    let mut app = cli::Args::into_app();
+    clap_complete::generate(shell, &mut app, "diffsitter", &mut io::stdout());
+}
+
 fn main() -> Result<()> {
     use cli::Command;
     let args = Args::parse();
@@ -264,6 +273,9 @@ fn main() -> Result<()> {
 
             #[cfg(feature = "better-build-info")]
             Command::BuildInfo => print_build_info(),
+            Command::GenCompletion { shell } => {
+                print_shell_completion(shell.into());
+            }
         }
     } else {
         let log_level = if args.debug {


### PR DESCRIPTION
Add a subcommand to generate shell completion scripts for a variety of
shells using `clap_complete`.
