### PR TITLE
feat: Character-level diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "0.0.25"
+version = "0.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba6aab796645620a69cbaca2eae382ce5bc5c86e15691a05e4b8676405280b2"
+checksum = "242c6293ad5acf5d9adb75231c1bd0c9cb0aecb64dd40e6579e36e0da7260f9b"
 dependencies = [
  "build-info-common",
  "build-info-proc",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "build-info-build"
-version = "0.0.25"
+version = "0.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a5f411661cae69a077c6c2e6b459c4474dd8507722abd7df5c5c3e77994332"
+checksum = "1ebfef0dcb94d65cc2cd98ce285de89ed40c9a1d2bb10175f548867d0e26cda0"
 dependencies = [
  "anyhow",
  "base64",
@@ -113,28 +113,28 @@ dependencies = [
  "glob",
  "lazy_static",
  "pretty_assertions",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde_json",
  "xz2",
 ]
 
 [[package]]
 name = "build-info-common"
-version = "0.0.25"
+version = "0.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2283a43c396636e32eb6a4c2c4bcec4b10fc78debe2d8964ab84fe149086b79"
+checksum = "db629469a6955021b15eb99cf5983ae8dcf9d0432ba2a8295715efee232da912"
 dependencies = [
  "chrono",
  "derive_more",
- "semver 1.0.4",
+ "semver",
  "serde",
 ]
 
 [[package]]
 name = "build-info-proc"
-version = "0.0.25"
+version = "0.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7bcaf579dd2d5343f257177f268fc6d8a86b23e46e50b08b371e579cfd757"
+checksum = "0965fa7159aa2cee4c5428ccec2d09dabb6ac5db2fe80d81cb8a158f5c47b335"
 dependencies = [
  "anyhow",
  "base64",
@@ -167,9 +167,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "camino"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 dependencies = [
  "serde",
 ]
@@ -191,13 +191,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.4",
+ "semver",
  "serde",
  "serde_json",
 ]
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.2"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
 dependencies = [
  "atty",
  "bitflags",
@@ -252,18 +252,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23eec4dd324308f49d8bf86a2732078c34d57955fec1e1d865554fc37c15d420"
+checksum = "df6f3613c0a3cddfd78b41b10203eb322cb29b600cbdf808a7d3db95691b8e25"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -295,9 +295,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -349,14 +349,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.3.3",
+ "rustc_version",
  "syn",
 ]
 
@@ -397,6 +397,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "tree-sitter",
+ "unicode-segmentation",
  "xdg",
 ]
 
@@ -449,12 +450,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -520,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -531,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.22"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1cbbfc9a1996c6af82c2b4caf828d2c653af4fcdbb0e5674cc966eee5a4197"
+checksum = "6e7d3b96ec1fcaa8431cf04a4f1ef5caafe58d5cf7bcc31f09c1626adddb0ffe"
 dependencies = [
  "bitflags",
  "libc",
@@ -591,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -601,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c0c443f6dceb3a1cb7607c87501aa91e4b9c976044f725c2a74ca2152c91a4"
+checksum = "30a7e1911532a662f6b08b68f884080850f2fd9544963c3ab23a5af42bda1eac"
 dependencies = [
  "console",
  "once_cell",
@@ -668,15 +663,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.23+1.2.0"
+version = "0.13.1+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29730a445bae719db3107078b46808cc45a5b7a6bae3f31272923af969453356"
+checksum = "43e598aa7a4faedf1ea1b4608f582b06f0f40211eec551b7ef36019ae3f62def"
 dependencies = [
  "cc",
  "libc",
@@ -774,18 +769,18 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -813,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -844,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "output_vt100"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
@@ -973,15 +968,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "pretty_assertions"
@@ -1037,9 +1032,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1052,23 +1047,22 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -1088,15 +1082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1162,33 +1147,24 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scopeguard"
@@ -1198,29 +1174,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -1256,12 +1214,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
  "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]
@@ -1286,9 +1244,9 @@ checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "strsim"
@@ -1320,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
  "terminal_size",
  "unicode-width",
@@ -1403,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1418,9 +1376,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e34327f8eac545e3f037382471b2b19367725a242bba7bc45edb9efb49fe39a"
+checksum = "9bd4f28f8febb994fca0bb3fd14360ac13cfc7d74d2a56d0f8e0d0e1c1ed7a1a"
 dependencies = [
  "cc",
  "regex",
@@ -1428,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -1449,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -1463,10 +1421,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
+name = "unicode-segmentation"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -1494,9 +1458,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,14 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tree-sitter = "0.20.4"
-clap = { version = "3.1.2", features = [
+tree-sitter = "0.20.5"
+clap = { version = "3.1.5", features = [
   "derive",
   "env",
   "unicode",
   "wrap_help",
 ] }
-clap_complete = "3.1.0"
+clap_complete = "3.1.1"
 anyhow = "1.0.55"
 phf = { version = "0.10.1", features = ["macros"] }
 console = "0.15.0"
@@ -53,9 +53,10 @@ pretty_env_logger = "0.4.0"
 log = { version = "0.4.14", features = ["std"] }
 thiserror = "1.0.30"
 logging_timer = "1.1.0"
-build-info = { version = "0.0.25", optional = true }
+build-info = { version = "0.0.26", optional = true }
 jemallocator = { version = "0.3.2", optional = true }
 libloading = "0.7.3"
+unicode-segmentation = "1.9.0"
 
 [dev-dependencies]
 test-case = "2.0.0"
@@ -64,7 +65,7 @@ pretty_assertions = "1.1.0"
 # We need the backtrace feature to enable snapshot name generation in
 # single-threaded tests (tests using cargo cross run single-threaded due to
 # limitations with QEMU).
-insta = { version = "1.12.0", features = ["backtrace"] }
+insta = { version = "1.13.0", features = ["backtrace"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # We use directories next to get the windows config path
@@ -81,7 +82,7 @@ anyhow = "1.0.55"
 cargo-emit = "0.2.1"
 rayon = "1.5.1"
 thiserror = "1.0.30"
-build-info-build = { version = "0.0.25", optional = true }
+build-info-build = { version = "0.0.26", optional = true }
 
 [features]
 default = ["static-grammar-libs"]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,12 +1,22 @@
 //! Utilities for processing the ASTs provided by `tree_sitter`
 
-use crate::diff::DiffEngine;
-use crate::diff::Hunks;
-use crate::diff::Myers;
+use crate::diff::{DiffEngine, Hunks, Myers};
 use logging_timer::time;
+use std::hash::{Hash, Hasher};
 use std::{cell::RefCell, ops::Index, path::PathBuf};
 use tree_sitter::Node as TSNode;
+use tree_sitter::Point;
 use tree_sitter::Tree as TSTree;
+use unicode_segmentation as us;
+
+/// The leaves of an AST vector
+///
+/// This is used as an intermediate struct for flattening the tree structure.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AstVectorLeaf<'a> {
+    pub reference: TSNode<'a>,
+    pub text: &'a str,
+}
 
 /// A mapping between a tree-sitter node and the text it corresponds to
 #[derive(Debug, Clone, Copy)]
@@ -22,6 +32,94 @@ pub struct Entry<'a> {
     /// This is different from the `source_text` that the [AstVector](AstVector) refers to, as the
     /// entry only holds a reference to the specific range of text that the node covers.
     pub text: &'a str,
+
+    /// The entry's start position in the document.
+    pub start_position: Point,
+
+    /// The entry's end position in the document.
+    pub end_position: Point,
+
+    /// The cached kind_id from the TSNode reference.
+    ///
+    /// Caching it here saves some time because it is queried repeatedly later.
+    pub kind_id: u16,
+}
+
+impl<'a> AstVectorLeaf<'a> {
+    /// Split an entry into a vector of entries per grapheme.
+    ///
+    /// Each grapheme will get its own [Entry] struct. This method will resolve the
+    /// indices/positioning of each grapheme from the `self.text` field.
+    fn split_graphemes(self) -> Vec<Entry<'a>> {
+        let mut entries = Vec::new();
+        let indices: Vec<(usize, &str)> =
+            us::UnicodeSegmentation::grapheme_indices(self.text, true).collect();
+        entries.reserve(indices.len());
+        let mut current_line = self.reference.start_position().row;
+
+        for (idx, grapheme) in indices {
+            // Every grapheme has to be at least one byte
+            debug_assert!(!grapheme.is_empty());
+
+            let original_start_col = self.reference.start_position().column;
+            let new_start_pos = Point {
+                row: current_line,
+                column: original_start_col + idx,
+            };
+            let new_end_pos = Point {
+                row: current_line,
+                column: new_start_pos.column + grapheme.len(),
+            };
+
+            debug_assert!(new_start_pos.row <= new_end_pos.row);
+
+            // If the end position is on the next row, then the column index can be less than or
+            // equal to the the start column. If they are on the same line, then the ending column
+            // *must be* greater than the starting column.
+            debug_assert!(
+                new_start_pos.column < new_end_pos.column || new_start_pos.row < new_end_pos.row
+            );
+
+            let entry = Entry {
+                reference: self.reference,
+                text: &self.text[idx..idx + grapheme.len()],
+                start_position: new_start_pos,
+                end_position: new_end_pos,
+                kind_id: self.reference.kind_id(),
+            };
+            entries.push(entry);
+
+            // If the last entry was a new line, iterate up for the next entry
+            if grapheme == "\n" || grapheme == "\r\n" {
+                current_line += 1;
+            }
+        }
+        entries
+    }
+}
+
+impl<'a> Entry<'a> {
+    /// Get the start position of an entry
+    pub fn start_position(&self) -> Point {
+        self.start_position
+    }
+
+    /// Get the end position of an entry
+    pub fn end_position(&self) -> Point {
+        self.end_position
+    }
+}
+
+impl<'a> From<&'a AstVector<'a>> for Vec<Entry<'a>> {
+    fn from(ast_vector: &'a AstVector<'a>) -> Self {
+        let mut entries = Vec::new();
+        entries.reserve(ast_vector.leaves.len());
+
+        for entry in &ast_vector.leaves {
+            entries.extend(entry.split_graphemes().iter());
+        }
+        entries
+    }
 }
 
 /// A vector that allows for linear traversal through the leafs of an AST.
@@ -31,7 +129,7 @@ pub struct Entry<'a> {
 #[derive(Debug)]
 pub struct AstVector<'a> {
     /// The leaves of the AST, build with an in-order traversal
-    pub leaves: Vec<Entry<'a>>,
+    pub leaves: Vec<AstVectorLeaf<'a>>,
 
     /// The full source text that the AST refers to
     pub source_text: &'a str,
@@ -79,16 +177,23 @@ impl<'a> AstVector<'a> {
 }
 
 impl<'a> Index<usize> for AstVector<'a> {
-    type Output = Entry<'a>;
+    type Output = AstVectorLeaf<'a>;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.leaves[index]
     }
 }
 
+impl<'a> Hash for AstVectorLeaf<'a> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.reference.kind_id().hash(state);
+        self.text.hash(state);
+    }
+}
+
 impl<'a> PartialEq for Entry<'a> {
     fn eq(&self, other: &Entry) -> bool {
-        self.text == other.text
+        self.kind_id == self.kind_id && self.text == other.text
     }
 }
 
@@ -98,16 +203,15 @@ impl<'a> PartialEq for AstVector<'a> {
             return false;
         }
 
-        // Zip through each entry to determine whether the elements are equal. We start with a
-        // `false` value for not equal and accumulate any inequalities along the way.
-        let not_equal = self
-            .leaves
-            .iter()
-            .zip(other.leaves.iter())
-            .fold(false, |not_equal, (entry_a, entry_b)| {
-                not_equal | (entry_a != entry_b)
-            });
-        !not_equal
+        for i in 0..self.leaves.len() {
+            let leaf = self.leaves[i];
+            let other_leaf = other.leaves[i];
+
+            if leaf != other_leaf {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -116,7 +220,7 @@ impl<'a> PartialEq for AstVector<'a> {
 /// This is a helper function that simply walks the tree and collects leaves in an in-order manner.
 /// Every time it encounters a leaf node, it stores the metadata and reference to the node in an
 /// `Entry` struct.
-fn build<'a>(vector: &RefCell<Vec<Entry<'a>>>, node: tree_sitter::Node<'a>, text: &'a str) {
+fn build<'a>(vector: &RefCell<Vec<AstVectorLeaf<'a>>>, node: tree_sitter::Node<'a>, text: &'a str) {
     // If the node is a leaf, we can stop traversing
     if node.child_count() == 0 {
         // We only push an entry if the referenced text range isn't empty, since there's no point
@@ -124,7 +228,7 @@ fn build<'a>(vector: &RefCell<Vec<Entry<'a>>>, node: tree_sitter::Node<'a>, text
         // because it would attempt to access the 0th index in an empty text range.
         if !node.byte_range().is_empty() {
             let node_text: &'a str = &text[node.byte_range()];
-            vector.borrow_mut().push(Entry {
+            vector.borrow_mut().push(AstVectorLeaf {
                 reference: node,
                 text: node_text,
             });
@@ -164,15 +268,19 @@ pub enum EditType<T> {
 #[time("info", "ast::{}")]
 pub fn compute_edit_script<'a>(a: &'a AstVector, b: &'a AstVector) -> (Hunks<'a>, Hunks<'a>) {
     let myers = Myers::default();
-    let edit_script = myers.diff(&a.leaves[..], &b.leaves[..]);
-    let mut old_edits = Vec::with_capacity(edit_script.len());
-    let mut new_edits = Vec::with_capacity(edit_script.len());
+    let a_graphemes: Vec<Entry> = a.into();
+    let b_graphemes: Vec<Entry> = b.into();
+    let edit_script = myers.diff(&a_graphemes[..], &b_graphemes[..]);
+    let edit_script_len = edit_script.len();
+
+    let mut old_edits = Vec::with_capacity(edit_script_len);
+    let mut new_edits = Vec::with_capacity(edit_script_len);
 
     for edit in edit_script {
         match edit {
-            EditType::Deletion(&edit) => old_edits.push(edit),
-            EditType::Addition(&edit) => new_edits.push(edit),
-        }
+            EditType::Deletion(&e) => old_edits.push(e),
+            EditType::Addition(&e) => new_edits.push(e),
+        };
     }
 
     // Convert the vectors of edits into hunks that can be displayed

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -113,10 +113,12 @@ pub enum HunkInsertionError {
         last_line: usize,
     },
 
-    #[error("Attempted to prepend an entry with a column ({incoming_col:?}) greater than the first entry's column ({last_col:?})")]
+    #[error("Attempted to append an entry with a column ({incoming_col:?}, line: {incoming_line:?}) less than the first entry's column ({last_col:?}, line: {last_line:?})")]
     PriorColumn {
         incoming_col: usize,
+        incoming_line: usize,
         last_col: usize,
+        last_line: usize,
     },
 }
 
@@ -144,7 +146,7 @@ impl<'a> Hunk<'a> {
     ///
     /// Entries can only be prepended in descending order (from last to first)
     pub fn push_front(&mut self, entry: Entry<'a>) -> Result<(), HunkInsertionError> {
-        let incoming_line_idx = entry.reference.start_position().row;
+        let incoming_line_idx = entry.start_position().row;
 
         // Add a new line vector if the entry has a greater line index, or if the vector is empty.
         // We ensure that the last line has the same line index as the incoming entry.
@@ -186,10 +188,10 @@ impl<'a> Hunk<'a> {
             //if let Some(&first_entry) = first_line.entries.front() {
             // TODO(afnan) ^ this instead?
             // TODO(afnan) should this be start_position() instead of end?
-            let first_col = first_entry.reference.end_position().column;
-            //let first_col = first_entry.reference.start_position().column;
+            let first_col = first_entry.end_position().column;
+            //let first_col = first_entry.start_position().column;
             // TODO(afnan) ^ this instead?
-            let incoming_col = entry.reference.end_position().column;
+            let incoming_col = entry.end_position().column;
 
             if incoming_col > first_col {
                 return Err(HunkInsertionError::LaterColumn {
@@ -208,7 +210,7 @@ impl<'a> Hunk<'a> {
     /// entries out of order. For example, you can't insert an entry on line 1 after inserting an
     /// entry on line 5.
     pub fn push_back(&mut self, entry: Entry<'a>) -> Result<(), HunkInsertionError> {
-        let incoming_line_idx = entry.reference.start_position().row;
+        let incoming_line_idx = entry.start_position().row;
 
         // Create a new line if the incoming entry is on the next line. This will throw an error
         // if we have an entry on a non-adjacent line or an out-of-order insertion.
@@ -235,19 +237,23 @@ impl<'a> Hunk<'a> {
         }
         // The lines are empty, we need to add the first one
         else {
-            self.0.push_back(Line::new(incoming_line_idx))
+            self.0.push_back(Line::new(incoming_line_idx));
         }
 
         let last_line = self.0.back_mut().unwrap();
 
         if let Some(&last_entry) = last_line.entries.back() {
-            let last_col = last_entry.reference.end_position().column;
-            let incoming_col = entry.reference.start_position().column;
+            let last_col = last_entry.end_position().column;
+            let last_line = last_entry.end_position().row;
+            let incoming_col = entry.start_position().column;
+            let incoming_line = entry.end_position().row;
 
             if incoming_col < last_col {
                 return Err(HunkInsertionError::PriorColumn {
                     incoming_col,
                     last_col,
+                    incoming_line,
+                    last_line,
                 });
             }
         }
@@ -316,6 +322,46 @@ impl<'a> Hunks<'a> {
             self.0.back_mut().unwrap().push_back(entry)?;
         }
         Ok(())
+    }
+}
+
+pub struct HunkAppender<'a>(pub Hunks<'a>);
+
+impl<'a> FromIterator<Entry<'a>> for HunkAppender<'a> {
+    /// Create an instance of `Hunks` from an iterator over [entries](Entry).
+    ///
+    /// The user is responsible for making sure that the hunks are in proper order, otherwise this
+    /// constructor may panic.
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Entry<'a>>,
+    {
+        let mut hunks = Hunks::new();
+
+        for i in iter {
+            hunks.push_back(i).expect("Invalid iterator");
+        }
+        HunkAppender(hunks)
+    }
+}
+
+pub struct HunkPrepender<'a>(pub Hunks<'a>);
+
+impl<'a> FromIterator<Entry<'a>> for HunkPrepender<'a> {
+    /// Create an instance of `Hunks` from an iterator over [entries](Entry).
+    ///
+    /// The user is responsible for making sure that the hunks are in proper order, otherwise this
+    /// constructor may panic.
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Entry<'a>>,
+    {
+        let mut hunks = Hunks::new();
+
+        for i in iter {
+            hunks.push_front(i).expect("Invalid iterator");
+        }
+        HunkPrepender(hunks)
     }
 }
 
@@ -557,7 +603,7 @@ impl Myers {
                         new_range.end,
                     );
 
-                    // NOTE: that we can convert x and y to `usize` because they are both within
+                    // NOTE: we can convert x and y to `usize` because they are both within
                     // the range of the length of the inputs, which are valid usize values. This property
                     // is also checked with assertions in debug releases.
                     if x + reverse_x >= n {

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -280,8 +280,6 @@ impl DiffWriter {
         old_fmt: &FormattingDirectives,
         new_fmt: &FormattingDirectives,
     ) -> std::io::Result<()> {
-        let divider = " -> ";
-
         // The different ways we can stack the title
         #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, strum_macros::Display)]
         #[strum(serialize_all = "snake_case")]
@@ -289,6 +287,7 @@ impl DiffWriter {
             Vertical,
             Horizontal,
         }
+        let divider = " -> ";
 
         // We construct the fully horizontal title string. If wider than the terminal, then we
         // format another title string that's vertically stacked
@@ -419,16 +418,16 @@ impl DiffWriter {
         // First, we print the prefix to stdout
         write!(term, "{}", regular.apply_to(fmt.prefix.as_ref()))?;
 
-        // The number of characters that have been printed out to stdout already. These aren't
-        // *actually* chars because UTF-8, but you get the gist.
+        // The number of characters that have been printed out to stdout already. All indices are
+        // in raw byte offsets, as splitting on graphemes, etc was taken care of when processing
+        // the AST nodes.
         let mut printed_chars = 0;
 
         // We keep printing ranges until we've covered the entire line
         for entry in &line.entries {
             // The range of text to emphasize
             // TODO(afnan) deal with ranges spanning multiple rows
-            let emphasis_range =
-                entry.reference.start_position().column..entry.reference.end_position().column;
+            let emphasis_range = entry.start_position().column..entry.end_position().column;
 
             // First we need to see if there's any regular text to cover. If the range has a len of
             // zero this is a no-op

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,9 +96,9 @@ fn generate_ast_vector_data(
     Ok(AstVectorData { text, tree, path })
 }
 
-/// Generate an AST vector from the underlying data
+/// Generate an AST vector from the underlying data.
 ///
-/// This is split off into a function so we can handle things like logging and keep the code DRY
+/// This will break up the AST vector data into a list of AST nodes that correspond to graphemes.
 fn generate_ast_vector(data: &AstVectorData) -> AstVector<'_> {
     let ast_vec = AstVector::from_ts_tree(&data.tree, &data.text);
     info!(
@@ -181,10 +181,11 @@ fn run_diff(args: &Args, config: &Config) -> Result<()> {
             text: &ast_data_b.text,
         },
     };
-    // Use a buffered terminal instead of a normal unbuffered terminal so we can amortize the cost of printing. It
-    // doesn't really how frequently the terminal prints to stdout because the user just cares about the output at the
-    // end, we don't care about how frequently the terminal does partial updates or anything like that. If the user is
-    // curious about progress, they can enable logging and see when hunks are processed and written to the buffer.
+    // Use a buffered terminal instead of a normal unbuffered terminal so we can amortize the cost
+    // of printing. It doesn't really matter how frequently the terminal prints to stdout because
+    // the user just cares about the output at the end, we don't care about how frequently the
+    // terminal does partial updates or anything like that. If the user is curious about progress,
+    // they can enable logging and see when hunks are processed and written to the buffer.
     let mut buf_writer = BufWriter::new(Term::stdout());
     config.formatting.print(&mut buf_writer, &params)?;
     // Just in case we forgot to flush anything in the `print` function
@@ -287,7 +288,6 @@ fn main() -> Result<()> {
             .filter_level(log_level)
             .init();
         set_term_colors(args.color_output);
-
         // First check if the input files can be parsed with tree-sitter.
         let files_supported = are_input_files_supported(&args, &config);
 
@@ -326,11 +326,14 @@ mod tests {
             "test data path {} does not exist",
             path_b.to_str().unwrap()
         );
+
         (path_a, path_b)
     }
 
     #[test_case("short", "rust", "rs")]
     #[test_case("short", "python", "py")]
+    #[test_case("medium", "rust", "rs")]
+    #[test_case("medium", "cpp", "cpp")]
     fn diff_hunks_snapshot(test_type: &str, name: &str, ext: &str) {
         let (path_a, path_b) = get_test_paths(test_type, name, ext);
         let config = GrammarConfig::default();

--- a/src/snapshots/diffsitter__tests__diff_hunks_snapshot__medium_cpp.snap
+++ b/src/snapshots/diffsitter__tests__diff_hunks_snapshot__medium_cpp.snap
@@ -1,0 +1,370 @@
+---
+source: src/main.rs
+assertion_line: 351
+expression: diff_hunks
+
+---
+(
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 17,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (17, 12) - (17, 13)},
+                                text: "j",
+                                start_position: Point {
+                                    row: 17,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 17,
+                                    column: 13,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (17, 24) - (17, 25)},
+                                text: "j",
+                                start_position: Point {
+                                    row: 17,
+                                    column: 24,
+                                },
+                                end_position: Point {
+                                    row: 17,
+                                    column: 25,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (17, 36) - (17, 37)},
+                                text: "j",
+                                start_position: Point {
+                                    row: 17,
+                                    column: 36,
+                                },
+                                end_position: Point {
+                                    row: 17,
+                                    column: 37,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 43,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (43, 7) - (43, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (43, 7) - (43, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 9,
+                                },
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 44,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (44, 7) - (44, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (44, 7) - (44, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 9,
+                                },
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 45,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (45, 7) - (45, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (45, 7) - (45, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 9,
+                                },
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 46,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (46, 7) - (46, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node :: (46, 7) - (46, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 9,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 12,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (12, 12) - (12, 13)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 12,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 12,
+                                    column: 13,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (12, 24) - (12, 25)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 12,
+                                    column: 24,
+                                },
+                                end_position: Point {
+                                    row: 12,
+                                    column: 25,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (12, 36) - (12, 37)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 12,
+                                    column: 36,
+                                },
+                                end_position: Point {
+                                    row: 12,
+                                    column: 37,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+)

--- a/src/snapshots/diffsitter__tests__diff_hunks_snapshot__medium_rust.snap
+++ b/src/snapshots/diffsitter__tests__diff_hunks_snapshot__medium_rust.snap
@@ -1,0 +1,741 @@
+---
+source: src/main.rs
+assertion_line: 351
+expression: diff_hunks
+
+---
+(
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 53,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (53, 7) - (53, 11)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 53,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 53,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (53, 7) - (53, 11)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 53,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 53,
+                                    column: 10,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (53, 7) - (53, 11)},
+                                text: "k",
+                                start_position: Point {
+                                    row: 53,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 53,
+                                    column: 11,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 61,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 13,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 14,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 14,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 15,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 15,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 16,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 16,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 17,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 64,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 9,
+                                },
+                            },
+                            Entry {
+                                reference: {Node . (64, 9) - (64, 10)},
+                                text: ".",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 10,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (64, 10) - (64, 14)},
+                                text: "a",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 11,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 12,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (64, 10) - (64, 14)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 13,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (64, 10) - (64, 14)},
+                                text: "k",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 14,
+                                },
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 65,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 9,
+                                },
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 66,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 9,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (66, 10) - (66, 14)},
+                                text: "a",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 11,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 12,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (66, 10) - (66, 14)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 13,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (66, 10) - (66, 14)},
+                                text: "k",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 14,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 2,
+                        entries: [
+                            Entry {
+                                reference: {Node , (2, 26) - (2, 27)},
+                                text: ",",
+                                start_position: Point {
+                                    row: 2,
+                                    column: 26,
+                                },
+                                end_position: Point {
+                                    row: 2,
+                                    column: 27,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 20,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (20, 4) - (20, 15)},
+                                text: "_",
+                                start_position: Point {
+                                    row: 20,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 20,
+                                    column: 13,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (20, 4) - (20, 15)},
+                                text: "f",
+                                start_position: Point {
+                                    row: 20,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 20,
+                                    column: 14,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (20, 4) - (20, 15)},
+                                text: "n",
+                                start_position: Point {
+                                    row: 20,
+                                    column: 14,
+                                },
+                                end_position: Point {
+                                    row: 20,
+                                    column: 15,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 42,
+                        entries: [
+                            Entry {
+                                reference: {Node , (42, 19) - (42, 20)},
+                                text: ",",
+                                start_position: Point {
+                                    row: 42,
+                                    column: 19,
+                                },
+                                end_position: Point {
+                                    row: 42,
+                                    column: 20,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 59,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "b",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 9,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 67,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (67, 9) - (67, 11)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 67,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 67,
+                                    column: 10,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (67, 9) - (67, 11)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 67,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 67,
+                                    column: 11,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 70,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (70, 1) - (70, 3)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 2,
+                                },
+                            },
+                            Entry {
+                                reference: {Node . (70, 3) - (70, 4)},
+                                text: ".",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 3,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 4,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "b",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "a",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 8,
+                                },
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 71,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (71, 1) - (71, 3)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 71,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 71,
+                                    column: 2,
+                                },
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 72,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (72, 1) - (72, 3)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 2,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (72, 1) - (72, 3)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 2,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 3,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (72, 4) - (72, 9)},
+                                text: "b",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (72, 4) - (72, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (72, 4) - (72, 9)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node field_identifier (72, 4) - (72, 9)},
+                                text: "a",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 8,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+)

--- a/src/snapshots/diffsitter__tests__diff_hunks_snapshot__short_python.snap
+++ b/src/snapshots/diffsitter__tests__diff_hunks_snapshot__short_python.snap
@@ -1,6 +1,6 @@
 ---
 source: src/main.rs
-assertion_line: 305
+assertion_line: 348
 expression: diff_hunks
 
 ---
@@ -17,7 +17,39 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node " (1, 4) - (1, 7)},
-                                text: "\"\"\"",
+                                text: "\"",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node " (1, 4) - (1, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node " (1, 4) - (1, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 7,
+                                },
                             },
                         ],
                     },
@@ -30,7 +62,39 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node " (3, 4) - (3, 7)},
-                                text: "\"\"\"",
+                                text: "\"",
+                                start_position: Point {
+                                    row: 3,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 3,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node " (3, 4) - (3, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 3,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 3,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node " (3, 4) - (3, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 3,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 3,
+                                    column: 7,
+                                },
                             },
                         ],
                     },
@@ -44,14 +108,38 @@ expression: diff_hunks
                             Entry {
                                 reference: {Node identifier (6, 4) - (6, 5)},
                                 text: "x",
+                                start_position: Point {
+                                    row: 6,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 6,
+                                    column: 5,
+                                },
                             },
                             Entry {
                                 reference: {Node = (6, 10) - (6, 11)},
                                 text: "=",
+                                start_position: Point {
+                                    row: 6,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 6,
+                                    column: 11,
+                                },
                             },
                             Entry {
                                 reference: {Node integer (6, 12) - (6, 13)},
                                 text: "1",
+                                start_position: Point {
+                                    row: 6,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 6,
+                                    column: 13,
+                                },
                             },
                         ],
                     },

--- a/src/snapshots/diffsitter__tests__diff_hunks_snapshot__short_rust.snap
+++ b/src/snapshots/diffsitter__tests__diff_hunks_snapshot__short_rust.snap
@@ -1,6 +1,6 @@
 ---
 source: src/main.rs
-assertion_line: 305
+assertion_line: 348
 expression: diff_hunks
 
 ---
@@ -14,23 +14,87 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node let (1, 4) - (1, 7)},
-                                text: "let",
+                                text: "l",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node let (1, 4) - (1, 7)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node let (1, 4) - (1, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 7,
+                                },
                             },
                             Entry {
                                 reference: {Node identifier (1, 8) - (1, 9)},
                                 text: "x",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 9,
+                                },
                             },
                             Entry {
                                 reference: {Node = (1, 10) - (1, 11)},
                                 text: "=",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 11,
+                                },
                             },
                             Entry {
                                 reference: {Node integer_literal (1, 12) - (1, 13)},
                                 text: "1",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 13,
+                                },
                             },
                             Entry {
                                 reference: {Node ; (1, 13) - (1, 14)},
                                 text: ";",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 14,
+                                },
                             },
                         ],
                     },
@@ -43,7 +107,27 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node identifier (4, 3) - (4, 10)},
-                                text: "add_one",
+                                text: "n",
+                                start_position: Point {
+                                    row: 4,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 4,
+                                    column: 9,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (4, 3) - (4, 10)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 4,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 4,
+                                    column: 10,
+                                },
                             },
                         ],
                     },
@@ -61,6 +145,14 @@ expression: diff_hunks
                             Entry {
                                 reference: {Node } (9, 0) - (9, 1)},
                                 text: "}",
+                                start_position: Point {
+                                    row: 9,
+                                    column: 0,
+                                },
+                                end_position: Point {
+                                    row: 9,
+                                    column: 1,
+                                },
                             },
                         ],
                     },
@@ -73,23 +165,159 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node fn (11, 0) - (11, 2)},
-                                text: "fn",
+                                text: "f",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 0,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 1,
+                                },
+                            },
+                            Entry {
+                                reference: {Node fn (11, 0) - (11, 2)},
+                                text: "n",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 2,
+                                },
                             },
                             Entry {
                                 reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "addition",
+                                text: "a",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 3,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 4,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 5,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 6,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 7,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 9,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 10,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "n",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 11,
+                                },
                             },
                             Entry {
                                 reference: {Node ( (11, 11) - (11, 12)},
                                 text: "(",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 11,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 12,
+                                },
                             },
                             Entry {
                                 reference: {Node ) (11, 12) - (11, 13)},
                                 text: ")",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 13,
+                                },
                             },
                             Entry {
                                 reference: {Node { (11, 14) - (11, 15)},
                                 text: "{",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 14,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 15,
+                                },
                             },
                         ],
                     },
@@ -102,15 +330,51 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node identifier (14, 3) - (14, 10)},
-                                text: "add_two",
+                                text: "t",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 8,
+                                },
+                            },
+                            Entry {
+                                reference: {Node identifier (14, 3) - (14, 10)},
+                                text: "w",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 9,
+                                },
                             },
                             Entry {
                                 reference: {Node ( (14, 10) - (14, 11)},
                                 text: "(",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 11,
+                                },
                             },
                             Entry {
                                 reference: {Node ) (14, 11) - (14, 12)},
                                 text: ")",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 11,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 12,
+                                },
                             },
                         ],
                     },

--- a/src/snapshots/diffsitter__tests__medium_cpp.snap
+++ b/src/snapshots/diffsitter__tests__medium_cpp.snap
@@ -1,0 +1,394 @@
+---
+source: src/main.rs
+expression: diff_hunks
+---
+(
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 17,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (17, 12) - (17, 13)},
+                                text: "j",
+                                start_position: Point {
+                                    row: 17,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 17,
+                                    column: 13,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (17, 24) - (17, 25)},
+                                text: "j",
+                                start_position: Point {
+                                    row: 17,
+                                    column: 24,
+                                },
+                                end_position: Point {
+                                    row: 17,
+                                    column: 25,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (17, 36) - (17, 37)},
+                                text: "j",
+                                start_position: Point {
+                                    row: 17,
+                                    column: 36,
+                                },
+                                end_position: Point {
+                                    row: 17,
+                                    column: 37,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 43,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 5,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 6,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 7,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node :: (43, 7) - (43, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (43, 7) - (43, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 9,
+                                },
+                                kind_id: 43,
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 44,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 5,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 6,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 7,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node :: (44, 7) - (44, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (44, 7) - (44, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 9,
+                                },
+                                kind_id: 43,
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 45,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 5,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 6,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 7,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node :: (45, 7) - (45, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (45, 7) - (45, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 9,
+                                },
+                                kind_id: 43,
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 46,
+                        entries: [
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "s",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 5,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 6,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 7,
+                                },
+                                kind_id: 420,
+                            },
+                            Entry {
+                                reference: {Node :: (46, 7) - (46, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (46, 7) - (46, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 9,
+                                },
+                                kind_id: 43,
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 12,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (12, 12) - (12, 13)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 12,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 12,
+                                    column: 13,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (12, 24) - (12, 25)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 12,
+                                    column: 24,
+                                },
+                                end_position: Point {
+                                    row: 12,
+                                    column: 25,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (12, 36) - (12, 37)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 12,
+                                    column: 36,
+                                },
+                                end_position: Point {
+                                    row: 12,
+                                    column: 37,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+)

--- a/src/snapshots/diffsitter__tests__medium_rust.snap
+++ b/src/snapshots/diffsitter__tests__medium_rust.snap
@@ -1,0 +1,765 @@
+---
+source: src/main.rs
+expression: diff_hunks
+---
+(
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 53,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (53, 7) - (53, 11)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 53,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 53,
+                                    column: 8,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (53, 7) - (53, 11)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 53,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 53,
+                                    column: 10,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (53, 7) - (53, 11)},
+                                text: "k",
+                                start_position: Point {
+                                    row: 53,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 53,
+                                    column: 11,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 61,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 13,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 14,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 14,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 15,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 15,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 16,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (61, 12) - (61, 17)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 61,
+                                    column: 16,
+                                },
+                                end_position: Point {
+                                    row: 61,
+                                    column: 17,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 64,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 6,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 7,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 8,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (64, 4) - (64, 9)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 9,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node . (64, 9) - (64, 10)},
+                                text: ".",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 10,
+                                },
+                                kind_id: 121,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (64, 10) - (64, 14)},
+                                text: "a",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 11,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 12,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (64, 10) - (64, 14)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 13,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (64, 10) - (64, 14)},
+                                text: "k",
+                                start_position: Point {
+                                    row: 64,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 64,
+                                    column: 14,
+                                },
+                                kind_id: 316,
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 65,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 6,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 7,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 8,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (65, 4) - (65, 9)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 65,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 65,
+                                    column: 9,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 66,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 6,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 8,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (66, 4) - (66, 9)},
+                                text: "y",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 9,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node . (66, 9) - (66, 10)},
+                                text: ".",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 10,
+                                },
+                                kind_id: 121,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (66, 10) - (66, 14)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 11,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (66, 10) - (66, 14)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 13,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (66, 10) - (66, 14)},
+                                text: "k",
+                                start_position: Point {
+                                    row: 66,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 66,
+                                    column: 14,
+                                },
+                                kind_id: 316,
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+    Hunks(
+        [
+            Hunk(
+                [
+                    Line {
+                        line_index: 2,
+                        entries: [
+                            Entry {
+                                reference: {Node , (2, 26) - (2, 27)},
+                                text: ",",
+                                start_position: Point {
+                                    row: 2,
+                                    column: 26,
+                                },
+                                end_position: Point {
+                                    row: 2,
+                                    column: 27,
+                                },
+                                kind_id: 79,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 20,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (20, 4) - (20, 15)},
+                                text: "_",
+                                start_position: Point {
+                                    row: 20,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 20,
+                                    column: 13,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (20, 4) - (20, 15)},
+                                text: "f",
+                                start_position: Point {
+                                    row: 20,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 20,
+                                    column: 14,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (20, 4) - (20, 15)},
+                                text: "n",
+                                start_position: Point {
+                                    row: 20,
+                                    column: 14,
+                                },
+                                end_position: Point {
+                                    row: 20,
+                                    column: 15,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 42,
+                        entries: [
+                            Entry {
+                                reference: {Node , (42, 19) - (42, 20)},
+                                text: ",",
+                                start_position: Point {
+                                    row: 42,
+                                    column: 19,
+                                },
+                                end_position: Point {
+                                    row: 42,
+                                    column: 20,
+                                },
+                                kind_id: 79,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 59,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "b",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 5,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 6,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 7,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (59, 4) - (59, 9)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 59,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 59,
+                                    column: 9,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 67,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (67, 9) - (67, 11)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 67,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 67,
+                                    column: 10,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (67, 9) - (67, 11)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 67,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 67,
+                                    column: 11,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                ],
+            ),
+            Hunk(
+                [
+                    Line {
+                        line_index: 70,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (70, 1) - (70, 3)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 2,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node . (70, 3) - (70, 4)},
+                                text: ".",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 3,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 4,
+                                },
+                                kind_id: 121,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "b",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 5,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "l",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 6,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 7,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (70, 4) - (70, 9)},
+                                text: "a",
+                                start_position: Point {
+                                    row: 70,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 70,
+                                    column: 8,
+                                },
+                                kind_id: 316,
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 71,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (71, 1) - (71, 3)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 71,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 71,
+                                    column: 2,
+                                },
+                                kind_id: 1,
+                            },
+                        ],
+                    },
+                    Line {
+                        line_index: 72,
+                        entries: [
+                            Entry {
+                                reference: {Node identifier (72, 1) - (72, 3)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 2,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node . (72, 3) - (72, 4)},
+                                text: ".",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 3,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 4,
+                                },
+                                kind_id: 121,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (72, 4) - (72, 9)},
+                                text: "b",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 5,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (72, 4) - (72, 9)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 7,
+                                },
+                                kind_id: 316,
+                            },
+                            Entry {
+                                reference: {Node field_identifier (72, 4) - (72, 9)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 72,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 72,
+                                    column: 9,
+                                },
+                                kind_id: 316,
+                            },
+                        ],
+                    },
+                ],
+            ),
+        ],
+    ),
+)

--- a/src/snapshots/diffsitter__tests__short_python.snap
+++ b/src/snapshots/diffsitter__tests__short_python.snap
@@ -1,8 +1,6 @@
 ---
 source: src/main.rs
-assertion_line: 347
 expression: diff_hunks
-
 ---
 (
     Hunks(
@@ -17,7 +15,42 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node " (1, 4) - (1, 7)},
-                                text: "\"\"\"",
+                                text: "\"",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                                kind_id: 102,
+                            },
+                            Entry {
+                                reference: {Node " (1, 4) - (1, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 6,
+                                },
+                                kind_id: 102,
+                            },
+                            Entry {
+                                reference: {Node " (1, 4) - (1, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 7,
+                                },
+                                kind_id: 102,
                             },
                         ],
                     },
@@ -30,7 +63,42 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node " (3, 4) - (3, 7)},
-                                text: "\"\"\"",
+                                text: "\"",
+                                start_position: Point {
+                                    row: 3,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 3,
+                                    column: 5,
+                                },
+                                kind_id: 102,
+                            },
+                            Entry {
+                                reference: {Node " (3, 4) - (3, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 3,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 3,
+                                    column: 6,
+                                },
+                                kind_id: 102,
+                            },
+                            Entry {
+                                reference: {Node " (3, 4) - (3, 7)},
+                                text: "\"",
+                                start_position: Point {
+                                    row: 3,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 3,
+                                    column: 7,
+                                },
+                                kind_id: 102,
                             },
                         ],
                     },
@@ -44,14 +112,41 @@ expression: diff_hunks
                             Entry {
                                 reference: {Node identifier (6, 4) - (6, 5)},
                                 text: "x",
+                                start_position: Point {
+                                    row: 6,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 6,
+                                    column: 5,
+                                },
+                                kind_id: 1,
                             },
                             Entry {
                                 reference: {Node = (6, 10) - (6, 11)},
                                 text: "=",
+                                start_position: Point {
+                                    row: 6,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 6,
+                                    column: 11,
+                                },
+                                kind_id: 46,
                             },
                             Entry {
                                 reference: {Node integer (6, 12) - (6, 13)},
                                 text: "1",
+                                start_position: Point {
+                                    row: 6,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 6,
+                                    column: 13,
+                                },
+                                kind_id: 92,
                             },
                         ],
                     },

--- a/src/snapshots/diffsitter__tests__short_rust.snap
+++ b/src/snapshots/diffsitter__tests__short_rust.snap
@@ -1,8 +1,6 @@
 ---
 source: src/main.rs
-assertion_line: 347
 expression: diff_hunks
-
 ---
 (
     Hunks(
@@ -14,23 +12,81 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node let (1, 4) - (1, 7)},
-                                text: "let",
+                                text: "l",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                                kind_id: 61,
+                            },
+                            Entry {
+                                reference: {Node let (1, 4) - (1, 7)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 6,
+                                },
+                                kind_id: 61,
                             },
                             Entry {
                                 reference: {Node identifier (1, 8) - (1, 9)},
                                 text: "x",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 9,
+                                },
+                                kind_id: 1,
                             },
                             Entry {
                                 reference: {Node = (1, 10) - (1, 11)},
                                 text: "=",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 11,
+                                },
+                                kind_id: 78,
                             },
                             Entry {
                                 reference: {Node integer_literal (1, 12) - (1, 13)},
                                 text: "1",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 13,
+                                },
+                                kind_id: 123,
                             },
                             Entry {
                                 reference: {Node ; (1, 13) - (1, 14)},
                                 text: ";",
+                                start_position: Point {
+                                    row: 1,
+                                    column: 13,
+                                },
+                                end_position: Point {
+                                    row: 1,
+                                    column: 14,
+                                },
+                                kind_id: 2,
                             },
                         ],
                     },
@@ -43,7 +99,29 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node identifier (4, 3) - (4, 10)},
-                                text: "add_one",
+                                text: "n",
+                                start_position: Point {
+                                    row: 4,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 4,
+                                    column: 9,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (4, 3) - (4, 10)},
+                                text: "e",
+                                start_position: Point {
+                                    row: 4,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 4,
+                                    column: 10,
+                                },
+                                kind_id: 1,
                             },
                         ],
                     },
@@ -61,6 +139,15 @@ expression: diff_hunks
                             Entry {
                                 reference: {Node } (9, 0) - (9, 1)},
                                 text: "}",
+                                start_position: Point {
+                                    row: 9,
+                                    column: 0,
+                                },
+                                end_position: Point {
+                                    row: 9,
+                                    column: 1,
+                                },
+                                kind_id: 7,
                             },
                         ],
                     },
@@ -73,23 +160,159 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node fn (11, 0) - (11, 2)},
-                                text: "fn",
+                                text: "f",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 0,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 1,
+                                },
+                                kind_id: 57,
+                            },
+                            Entry {
+                                reference: {Node fn (11, 0) - (11, 2)},
+                                text: "n",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 1,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 2,
+                                },
+                                kind_id: 57,
                             },
                             Entry {
                                 reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "addition",
+                                text: "a",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 3,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 4,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 4,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 5,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 6,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 7,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "i",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 9,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "o",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 9,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 10,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (11, 3) - (11, 11)},
+                                text: "n",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 11,
+                                },
+                                kind_id: 1,
                             },
                             Entry {
                                 reference: {Node ( (11, 11) - (11, 12)},
                                 text: "(",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 11,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 12,
+                                },
+                                kind_id: 4,
                             },
                             Entry {
                                 reference: {Node ) (11, 12) - (11, 13)},
                                 text: ")",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 12,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 13,
+                                },
+                                kind_id: 5,
                             },
                             Entry {
                                 reference: {Node { (11, 14) - (11, 15)},
                                 text: "{",
+                                start_position: Point {
+                                    row: 11,
+                                    column: 14,
+                                },
+                                end_position: Point {
+                                    row: 11,
+                                    column: 15,
+                                },
+                                kind_id: 6,
                             },
                         ],
                     },
@@ -102,15 +325,55 @@ expression: diff_hunks
                         entries: [
                             Entry {
                                 reference: {Node identifier (14, 3) - (14, 10)},
-                                text: "add_two",
+                                text: "t",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 7,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 8,
+                                },
+                                kind_id: 1,
+                            },
+                            Entry {
+                                reference: {Node identifier (14, 3) - (14, 10)},
+                                text: "w",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 9,
+                                },
+                                kind_id: 1,
                             },
                             Entry {
                                 reference: {Node ( (14, 10) - (14, 11)},
                                 text: "(",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 10,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 11,
+                                },
+                                kind_id: 4,
                             },
                             Entry {
                                 reference: {Node ) (14, 11) - (14, 12)},
                                 text: ")",
+                                start_position: Point {
+                                    row: 14,
+                                    column: 11,
+                                },
+                                end_position: Point {
+                                    row: 14,
+                                    column: 12,
+                                },
+                                kind_id: 5,
                             },
                         ],
                     },

--- a/test_data/medium/cpp/a.cpp
+++ b/test_data/medium/cpp/a.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+using namespace std;
+
+int main()
+{
+    char line[150];
+    int vowels, consonants, digits, spaces;
+
+    vowels =  
+
+
+consonants = digits = spaces = 0;
+
+    cout << "Enter a line of string: ";
+    cin.getline(
+		line, 150);
+
+    for(int j = 0; line[j]!='\0'; ++j)
+    {
+        if(line[i]=='a' || line[i]=='e' || line[i]=='i' ||
+           line[i]=='o' || line[i]=='u' || line[i]=='A' ||
+           line[i]=='E' || line[i]=='I' || line[i]=='O' ||
+           line[i]=='U')
+        {
+            ++vowels;
+        }
+
+        else if((line[i]>='a'&& line[i]<='z') || (line[i]>='A'&& line[i]<='Z'))
+        {
+            ++consonants;
+        }
+
+        else if(line[i]>='0' && line[i]<='9')
+        {
+            ++digits;
+        }
+
+        else if (line[i]==' ')
+        {
+            ++spaces;
+        }
+    }
+
+    std::cout << "Vowels: " << vowels << endl;
+    std::cout << "Consonants: " << consonants << endl;
+    std::cout << "Digits: " << digits << endl;
+    std::cout << "White spaces: " << spaces << endl;
+
+    return 0;
+}

--- a/test_data/medium/cpp/b.cpp
+++ b/test_data/medium/cpp/b.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+using namespace std;
+
+int main()
+{
+    char line[150];
+    int vowels, consonants, digits, spaces;
+
+    vowels =  consonants = digits = spaces = 0;
+
+    cout << "Enter a line of string: ";
+    cin.getline(line, 150);
+    for(int i = 0; line[i]!='\0'; ++i) {
+        if(line[i]=='a' || line[i]=='e' || line[i]=='i' ||
+           line[i]=='o' || line[i]=='u' || line[i]=='A' ||
+           line[i]=='E' || line[i]=='I' || line[i]=='O' ||
+           line[i]=='U') {
+            ++vowels;
+        }
+        else if((line[i]>='a'&& line[i]<='z') || (line[i]>='A'&& line[i]<='Z')) {
+            ++consonants;
+        }
+        else if(line[i]>='0' && line[i]<='9') {
+            ++digits;
+        }
+        else if (line[i]==' ') {
+            ++spaces;
+        }
+    }
+
+    cout << "Vowels: " << vowels << endl;
+    cout << "Consonants: " << consonants << endl;
+    cout << "Digits: " << digits << endl;
+    cout << "White spaces: " << spaces << endl;
+
+    return 0;
+}

--- a/test_data/medium/rust/a.rs
+++ b/test_data/medium/rust/a.rs
@@ -1,0 +1,68 @@
+struct Sheep { naked: bool, name: &'static str }
+
+trait Animal {
+    // Associated function signature; `Self` refers to the implementor type.
+    fn new(name: &'static str) -> Self;
+
+    // Method signatures; these will return a string.
+    fn name(&self) -> &'static str;
+    fn noise(&self) -> &'static str;
+
+    // Traits can provide default method definitions.
+    fn talk(&self) {
+        println!("{} says {}", self.name(), self.noise());
+    }
+}
+
+impl Sheep {
+    fn is_naked(&self) -> bool {
+        self.naked
+    }
+
+    fn shear(&mut self) {
+        if self.is_naked() {
+            // Implementor methods can use the implementor's trait methods.
+            println!("{} is already naked...", self.name());
+        } else {
+            println!("{} gets a haircut!", self.name);
+
+            self.naked = true;
+        }
+    }
+}
+
+// Implement the `Animal` trait for `Sheep`.
+impl Animal for Sheep {
+    // `Self` is the implementor type: `Sheep`.
+    fn new(name: &'static str) -> Sheep {
+        Sheep { name: name, naked: false }
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn noise(&self) -> &'static str {
+        if self.is_naked() {
+            "baaaaah?"
+        } else {
+            "baaaaah!"
+        }
+    }
+    
+    // Default trait methods can be overridden.
+    fn talk(&self) {
+        // For example, we can add some quiet contemplation.
+        println!("{} pauses briefly... {}", self.name, self.noise());
+    }
+}
+
+fn main() {
+    // Type annotation is necessary in this case.
+    let mut dolly: Sheep = Animal::new("Dolly");
+    // TODO ^ Try removing the type annotations.
+
+    dolly.talk();
+    dolly.shear();
+    dolly.talk();
+}

--- a/test_data/medium/rust/b.rs
+++ b/test_data/medium/rust/b.rs
@@ -1,0 +1,75 @@
+struct Sheep {
+naked: bool,
+	       name: &'static str,
+}
+
+trait Animal {
+	// Associated function signature; `Self` refers to the implementor type.
+	fn new(name: &'static str) -> Self;
+
+	// Method signatures; these will return a string.
+	fn name(&self) -> &'static str;
+	fn noise(&self) -> &'static str;
+
+	// Traits can provide default method definitions.
+	fn talk(&self) {
+		println!("{} says {}", self.name(), self.noise());
+	}
+}
+
+impl Sheep {
+	fn is_naked_fn(&self) -> bool {
+		self.naked
+	}
+
+	fn shear(&mut self) {
+		if self.is_naked() {
+			// Implementor methods can use the implementor's trait methods.
+			println!("{} is already naked...", self.name());
+		} else {
+			println!("{} gets a haircut!", self.name);
+
+			self.naked = true;
+		}
+	}
+}
+
+// Implement the `Animal` trait for `Sheep`.
+impl Animal for Sheep {
+	// `Self` is the implementor type: `Sheep`.
+	fn new(name: &'static str) -> Sheep {
+		Sheep {
+name: name,
+	      naked: false,
+		}
+	}
+
+	fn name(&self) -> &'static str {
+		self.name
+	}
+
+	fn noise(&self) -> &'static str {
+		if self.is_naked() {
+			"baaaaah?"
+		} else {
+			"baaaaah!"
+		}
+	}
+
+	// Default trait methods can be overridden.
+	fn bleat(&self) {
+		// For example, we can add some quiet contemplation.
+		println!("{} beats briefly... {}", self.name, self.noise());
+	}
+}
+
+fn main() {
+	// Type annotation is necessary in this case.
+	let mut ed: Sheep = Animal::new("Logan");
+	// TODO ^ Try removing the type annotations.
+
+	ed.bleat();
+	ed.shear();
+	ed.bleat();
+}
+


### PR DESCRIPTION
Up until this commit, `diffsitter` has computed diffs by directing
comparing the equality of the text of two nodes. This means that if two
nodes had text content that was unequal *at all*, the contents of that
*entire* node would be considered a difference.

As a concrete example, consider the two snippets:

```rust
fn example_a() {}

fn example_b() {}
```

The diff would see the text corresponding to the identifiers for each
function are different, so the corresponding diff would be:

```
-example_a
+example_b
```

Because we just check if `"example_a" == "example_b"`. What we really
want is:

```
-a
+b
```

We are able to achieve this by breaking up each node into `Entry`
objects that correspond to a single unicode grapheme, so when the diffs
are computed, they are on a per-grapheme basis rather than at a per-node
basis. Of course, the actual diff mechanism is generic, so we only have
to modify how the `Entry` object is created, and the diff and hunk
construction mechanisms remain unchanged.

This PR also adds test cases for medium-length source files.

We merged and reverted a similar PR before because of performance issues. This is being re-opened now that the performance issues have been addressed. We were able to make this much faster by caching the result of the `kind_id()` FFI function call in the `Entry` struct.