### PR TITLE
refactor: Exhaustive variant match

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,7 @@ fn set_term_colors(color_opt: ColorOutputPolicy) {
     match color_opt {
         ColorOutputPolicy::Off => (console::set_colors_enabled(false)),
         ColorOutputPolicy::On => (console::set_colors_enabled(true)),
-        _ => (),
+        ColorOutputPolicy::Auto => (),
     };
 }
 


### PR DESCRIPTION
Address a clippy lint and exhaustively pattern match. This will prevent
unintended consequences if another variant is added in the future.
