### PR TITLE
feat: Strip binary in production profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,5 @@ static-grammar-libs = []
 inherits = "release"
 lto = true
 codegen-units = 1
+# Makes the binary a little smaller
+strip = true


### PR DESCRIPTION
Strip the prod binary to keep binary sizes a little smaller.
