### PR TITLE
feat: Better ordering for diff hunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ languages supported by tree-sitter.
 
 Take the following files:
 
-[`a.rs`](test_data/test_1_a.rs)
+[`a.rs`](test_data/short/rust/a.rs)
 
 ```rust
 fn main() {
@@ -57,7 +57,7 @@ fn add_one {
 }
 ```
 
-[`b.rs`](test_data/test_1_b.rs)
+[`b.rs`](test_data/short/rust/b.rs)
 
 ```rust
 fn
@@ -108,17 +108,9 @@ function, even though they aren't semantically different.
 
 Check out the output from `diffsitter`:
 
-```text
-test_data/test_1_a.rs -> test_data/test_1_b.rs
-==============================================
-
-1:
---
--     let x = 1;
-
-4:
---
-- fn add_one {
+```
+test_data/short/rust/a.rs -> test_data/short/rust/b.rs
+======================================================
 
 9:
 --
@@ -128,9 +120,17 @@ test_data/test_1_a.rs -> test_data/test_1_b.rs
 ---
 + fn addition() {
 
+1:
+--
+-     let x = 1;
+
 14:
 ---
 + fn add_two() {
+
+4:
+--
+- fn add_one {
 ```
 
 *Note: the numbers correspond to line numbers from the original files.*

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,25 +151,22 @@ fn run_diff(args: &Args, config: &Config) -> Result<()> {
 
     let ast_data_a = generate_ast_vector_data(path_a.clone(), file_type, &config.grammar)?;
     let ast_data_b = generate_ast_vector_data(path_b.clone(), file_type, &config.grammar)?;
-
     let diff_vec_a = config
         .input_processing
         .process(&ast_data_a.tree, &ast_data_a.text);
-
     let diff_vec_b = config
         .input_processing
         .process(&ast_data_b.tree, &ast_data_b.text);
 
-    let (old_hunks, new_hunks) = diff::compute_edit_script(&diff_vec_a, &diff_vec_b);
+    let hunks = diff::compute_edit_script(&diff_vec_a, &diff_vec_b)?;
     let params = DisplayParameters {
+        hunks,
         old: DocumentDiffData {
             filename: &ast_data_a.path.to_string_lossy(),
-            hunks: &old_hunks,
             text: &ast_data_a.text,
         },
         new: DocumentDiffData {
             filename: &ast_data_b.path.to_string_lossy(),
-            hunks: &new_hunks,
             text: &ast_data_b.text,
         },
     };

--- a/src/snapshots/diffsitter__tests__medium_cpp_false.snap
+++ b/src/snapshots/diffsitter__tests__medium_cpp_false.snap
@@ -2,236 +2,238 @@
 source: src/main.rs
 expression: diff_hunks
 ---
-(
-    Hunks(
+Ok(
+    RichHunks(
         [
-            Hunk(
-                [
-                    Line {
-                        line_index: 17,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (17, 12) - (17, 13)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 12,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 12,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (12, 12) - (12, 13)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 12,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 12,
+                                        column: 12,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 12,
+                                Entry {
+                                    reference: {Node identifier (12, 24) - (12, 25)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 12,
+                                        column: 24,
+                                    },
+                                    end_position: Point {
+                                        row: 12,
+                                        column: 24,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 24) - (17, 25)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 24,
+                                Entry {
+                                    reference: {Node identifier (12, 36) - (12, 37)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 12,
+                                        column: 36,
+                                    },
+                                    end_position: Point {
+                                        row: 12,
+                                        column: 36,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 24,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 36) - (17, 37)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 36,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 36,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 43,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 4,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 17,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (17, 12) - (17, 13)},
+                                    text: "j",
+                                    start_position: Point {
+                                        row: 17,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 17,
+                                        column: 12,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 4,
+                                Entry {
+                                    reference: {Node identifier (17, 24) - (17, 25)},
+                                    text: "j",
+                                    start_position: Point {
+                                        row: 17,
+                                        column: 24,
+                                    },
+                                    end_position: Point {
+                                        row: 17,
+                                        column: 24,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (43, 7) - (43, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 7,
+                                Entry {
+                                    reference: {Node identifier (17, 36) - (17, 37)},
+                                    text: "j",
+                                    start_position: Point {
+                                        row: 17,
+                                        column: 36,
+                                    },
+                                    end_position: Point {
+                                        row: 17,
+                                        column: 36,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 7,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 44,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 4,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (44, 7) - (44, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 45,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 4,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (45, 7) - (45, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 46,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 4,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (46, 7) - (46, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-        ],
-    ),
-    Hunks(
-        [
-            Hunk(
-                [
-                    Line {
-                        line_index: 12,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (12, 12) - (12, 13)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 12,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 43,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                    text: "std",
+                                    start_position: Point {
+                                        row: 43,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 43,
+                                        column: 4,
+                                    },
+                                    kind_id: 420,
                                 },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 12,
+                                Entry {
+                                    reference: {Node :: (43, 7) - (43, 9)},
+                                    text: "::",
+                                    start_position: Point {
+                                        row: 43,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 43,
+                                        column: 7,
+                                    },
+                                    kind_id: 43,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 24) - (12, 25)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 24,
+                            ],
+                        },
+                        Line {
+                            line_index: 44,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                    text: "std",
+                                    start_position: Point {
+                                        row: 44,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 44,
+                                        column: 4,
+                                    },
+                                    kind_id: 420,
                                 },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 24,
+                                Entry {
+                                    reference: {Node :: (44, 7) - (44, 9)},
+                                    text: "::",
+                                    start_position: Point {
+                                        row: 44,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 44,
+                                        column: 7,
+                                    },
+                                    kind_id: 43,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 36) - (12, 37)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 36,
+                            ],
+                        },
+                        Line {
+                            line_index: 45,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                    text: "std",
+                                    start_position: Point {
+                                        row: 45,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 45,
+                                        column: 4,
+                                    },
+                                    kind_id: 420,
                                 },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 36,
+                                Entry {
+                                    reference: {Node :: (45, 7) - (45, 9)},
+                                    text: "::",
+                                    start_position: Point {
+                                        row: 45,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 45,
+                                        column: 7,
+                                    },
+                                    kind_id: 43,
                                 },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                        Line {
+                            line_index: 46,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                    text: "std",
+                                    start_position: Point {
+                                        row: 46,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 46,
+                                        column: 4,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node :: (46, 7) - (46, 9)},
+                                    text: "::",
+                                    start_position: Point {
+                                        row: 46,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 46,
+                                        column: 7,
+                                    },
+                                    kind_id: 43,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
         ],
     ),

--- a/src/snapshots/diffsitter__tests__medium_cpp_true.snap
+++ b/src/snapshots/diffsitter__tests__medium_cpp_true.snap
@@ -2,392 +2,394 @@
 source: src/main.rs
 expression: diff_hunks
 ---
-(
-    Hunks(
+Ok(
+    RichHunks(
         [
-            Hunk(
-                [
-                    Line {
-                        line_index: 17,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (17, 12) - (17, 13)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 12,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 12,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (12, 12) - (12, 13)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 12,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 12,
+                                        column: 13,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 13,
+                                Entry {
+                                    reference: {Node identifier (12, 24) - (12, 25)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 12,
+                                        column: 24,
+                                    },
+                                    end_position: Point {
+                                        row: 12,
+                                        column: 25,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 24) - (17, 25)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 24,
+                                Entry {
+                                    reference: {Node identifier (12, 36) - (12, 37)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 12,
+                                        column: 36,
+                                    },
+                                    end_position: Point {
+                                        row: 12,
+                                        column: 37,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 25,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 36) - (17, 37)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 36,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 37,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 43,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 4,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 17,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (17, 12) - (17, 13)},
+                                    text: "j",
+                                    start_position: Point {
+                                        row: 17,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 17,
+                                        column: 13,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node identifier (17, 24) - (17, 25)},
+                                    text: "j",
+                                    start_position: Point {
+                                        row: 17,
+                                        column: 24,
+                                    },
+                                    end_position: Point {
+                                        row: 17,
+                                        column: 25,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node identifier (17, 36) - (17, 37)},
+                                    text: "j",
+                                    start_position: Point {
+                                        row: 17,
+                                        column: 36,
+                                    },
+                                    end_position: Point {
+                                        row: 17,
+                                        column: 37,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 6,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 7,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (43, 7) - (43, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (43, 7) - (43, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 9,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 44,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 5,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 6,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (44, 7) - (44, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (44, 7) - (44, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 9,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 45,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 5,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 6,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (45, 7) - (45, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (45, 7) - (45, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 9,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 46,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 5,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 6,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                kind_id: 420,
-                            },
-                            Entry {
-                                reference: {Node :: (46, 7) - (46, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (46, 7) - (46, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 9,
-                                },
-                                kind_id: 43,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-        ],
-    ),
-    Hunks(
-        [
-            Hunk(
-                [
-                    Line {
-                        line_index: 12,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (12, 12) - (12, 13)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 12,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 43,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                    text: "s",
+                                    start_position: Point {
+                                        row: 43,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 43,
+                                        column: 5,
+                                    },
+                                    kind_id: 420,
                                 },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 13,
+                                Entry {
+                                    reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 43,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 43,
+                                        column: 6,
+                                    },
+                                    kind_id: 420,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 24) - (12, 25)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 24,
+                                Entry {
+                                    reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 43,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 43,
+                                        column: 7,
+                                    },
+                                    kind_id: 420,
                                 },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 25,
+                                Entry {
+                                    reference: {Node :: (43, 7) - (43, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 43,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 43,
+                                        column: 8,
+                                    },
+                                    kind_id: 43,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 36) - (12, 37)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 36,
+                                Entry {
+                                    reference: {Node :: (43, 7) - (43, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 43,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 43,
+                                        column: 9,
+                                    },
+                                    kind_id: 43,
                                 },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 37,
+                            ],
+                        },
+                        Line {
+                            line_index: 44,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                    text: "s",
+                                    start_position: Point {
+                                        row: 44,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 44,
+                                        column: 5,
+                                    },
+                                    kind_id: 420,
                                 },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                                Entry {
+                                    reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 44,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 44,
+                                        column: 6,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 44,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 44,
+                                        column: 7,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node :: (44, 7) - (44, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 44,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 44,
+                                        column: 8,
+                                    },
+                                    kind_id: 43,
+                                },
+                                Entry {
+                                    reference: {Node :: (44, 7) - (44, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 44,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 44,
+                                        column: 9,
+                                    },
+                                    kind_id: 43,
+                                },
+                            ],
+                        },
+                        Line {
+                            line_index: 45,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                    text: "s",
+                                    start_position: Point {
+                                        row: 45,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 45,
+                                        column: 5,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 45,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 45,
+                                        column: 6,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 45,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 45,
+                                        column: 7,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node :: (45, 7) - (45, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 45,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 45,
+                                        column: 8,
+                                    },
+                                    kind_id: 43,
+                                },
+                                Entry {
+                                    reference: {Node :: (45, 7) - (45, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 45,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 45,
+                                        column: 9,
+                                    },
+                                    kind_id: 43,
+                                },
+                            ],
+                        },
+                        Line {
+                            line_index: 46,
+                            entries: [
+                                Entry {
+                                    reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                    text: "s",
+                                    start_position: Point {
+                                        row: 46,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 46,
+                                        column: 5,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 46,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 46,
+                                        column: 6,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 46,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 46,
+                                        column: 7,
+                                    },
+                                    kind_id: 420,
+                                },
+                                Entry {
+                                    reference: {Node :: (46, 7) - (46, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 46,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 46,
+                                        column: 8,
+                                    },
+                                    kind_id: 43,
+                                },
+                                Entry {
+                                    reference: {Node :: (46, 7) - (46, 9)},
+                                    text: ":",
+                                    start_position: Point {
+                                        row: 46,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 46,
+                                        column: 9,
+                                    },
+                                    kind_id: 43,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
         ],
     ),

--- a/src/snapshots/diffsitter__tests__medium_rust_false.snap
+++ b/src/snapshots/diffsitter__tests__medium_rust_false.snap
@@ -2,356 +2,372 @@
 source: src/main.rs
 expression: diff_hunks
 ---
-(
-    Hunks(
+Ok(
+    RichHunks(
         [
-            Hunk(
-                [
-                    Line {
-                        line_index: 17,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (17, 7) - (17, 15)},
-                                text: "is_naked",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 7,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 2,
+                            entries: [
+                                Entry {
+                                    reference: {Node , (2, 26) - (2, 27)},
+                                    text: ",",
+                                    start_position: Point {
+                                        row: 2,
+                                        column: 26,
+                                    },
+                                    end_position: Point {
+                                        row: 2,
+                                        column: 26,
+                                    },
+                                    kind_id: 123,
                                 },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 53,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "talk",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 7,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 20,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (20, 4) - (20, 15)},
+                                    text: "is_naked_fn",
+                                    start_position: Point {
+                                        row: 20,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 20,
+                                        column: 4,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 61,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 12,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 17,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (17, 7) - (17, 15)},
+                                    text: "is_naked",
+                                    start_position: Point {
+                                        row: 17,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 17,
+                                        column: 7,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 12,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 64,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 4,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 42,
+                            entries: [
+                                Entry {
+                                    reference: {Node , (42, 19) - (42, 20)},
+                                    text: ",",
+                                    start_position: Point {
+                                        row: 42,
+                                        column: 19,
+                                    },
+                                    end_position: Point {
+                                        row: 42,
+                                        column: 19,
+                                    },
+                                    kind_id: 123,
                                 },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "talk",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 10,
-                                },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 65,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 66,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "talk",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 10,
-                                },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-        ],
-    ),
-    Hunks(
-        [
-            Hunk(
-                [
-                    Line {
-                        line_index: 2,
-                        entries: [
-                            Entry {
-                                reference: {Node , (2, 26) - (2, 27)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 2,
-                                    column: 26,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 59,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (59, 4) - (59, 9)},
+                                    text: "bleat",
+                                    start_position: Point {
+                                        row: 59,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 59,
+                                        column: 4,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 2,
-                                    column: 26,
-                                },
-                                kind_id: 123,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 20,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "is_naked_fn",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 4,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 53,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (53, 7) - (53, 11)},
+                                    text: "talk",
+                                    start_position: Point {
+                                        row: 53,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 53,
+                                        column: 7,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 42,
-                        entries: [
-                            Entry {
-                                reference: {Node , (42, 19) - (42, 20)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 42,
-                                    column: 19,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 61,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (61, 12) - (61, 17)},
+                                    text: "dolly",
+                                    start_position: Point {
+                                        row: 61,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 61,
+                                        column: 12,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 42,
-                                    column: 19,
-                                },
-                                kind_id: 123,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 59,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "bleat",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 4,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 67,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (67, 9) - (67, 11)},
+                                    text: "ed",
+                                    start_position: Point {
+                                        row: 67,
+                                        column: 9,
+                                    },
+                                    end_position: Point {
+                                        row: 67,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 67,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (67, 9) - (67, 11)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 9,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 70,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (70, 1) - (70, 3)},
+                                    text: "ed",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 1,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 1,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 9,
+                                Entry {
+                                    reference: {Node field_identifier (70, 4) - (70, 9)},
+                                    text: "bleat",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 4,
+                                    },
+                                    kind_id: 368,
                                 },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                        Line {
+                            line_index: 71,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (71, 1) - (71, 3)},
+                                    text: "ed",
+                                    start_position: Point {
+                                        row: 71,
+                                        column: 1,
+                                    },
+                                    end_position: Point {
+                                        row: 71,
+                                        column: 1,
+                                    },
+                                    kind_id: 1,
+                                },
+                            ],
+                        },
+                        Line {
+                            line_index: 72,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (72, 1) - (72, 3)},
+                                    text: "ed",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 1,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 1,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node field_identifier (72, 4) - (72, 9)},
+                                    text: "bleat",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 4,
+                                    },
+                                    kind_id: 368,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 70,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (70, 1) - (70, 3)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 1,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 64,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (64, 4) - (64, 9)},
+                                    text: "dolly",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 4,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 1,
+                                Entry {
+                                    reference: {Node field_identifier (64, 10) - (64, 14)},
+                                    text: "talk",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 10,
+                                    },
+                                    kind_id: 368,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "bleat",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 4,
+                            ],
+                        },
+                        Line {
+                            line_index: 65,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (65, 4) - (65, 9)},
+                                    text: "dolly",
+                                    start_position: Point {
+                                        row: 65,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 65,
+                                        column: 4,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 4,
+                            ],
+                        },
+                        Line {
+                            line_index: 66,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (66, 4) - (66, 9)},
+                                    text: "dolly",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 4,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 71,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (71, 1) - (71, 3)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 71,
-                                    column: 1,
+                                Entry {
+                                    reference: {Node field_identifier (66, 10) - (66, 14)},
+                                    text: "talk",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 10,
+                                    },
+                                    kind_id: 368,
                                 },
-                                end_position: Point {
-                                    row: 71,
-                                    column: 1,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 72,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (72, 1) - (72, 3)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 1,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "bleat",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 4,
-                                },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
         ],
     ),

--- a/src/snapshots/diffsitter__tests__medium_rust_true.snap
+++ b/src/snapshots/diffsitter__tests__medium_rust_true.snap
@@ -2,789 +2,803 @@
 source: src/main.rs
 expression: diff_hunks
 ---
-(
-    Hunks(
+Ok(
+    RichHunks(
         [
-            Hunk(
-                [
-                    Line {
-                        line_index: 53,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 7,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 2,
+                            entries: [
+                                Entry {
+                                    reference: {Node , (2, 26) - (2, 27)},
+                                    text: ",",
+                                    start_position: Point {
+                                        row: 2,
+                                        column: 26,
+                                    },
+                                    end_position: Point {
+                                        row: 2,
+                                        column: 27,
+                                    },
+                                    kind_id: 123,
                                 },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 10,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "k",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 11,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 61,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 12,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 20,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (20, 4) - (20, 15)},
+                                    text: "_",
+                                    start_position: Point {
+                                        row: 20,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 20,
+                                        column: 13,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 13,
+                                Entry {
+                                    reference: {Node identifier (20, 4) - (20, 15)},
+                                    text: "f",
+                                    start_position: Point {
+                                        row: 20,
+                                        column: 13,
+                                    },
+                                    end_position: Point {
+                                        row: 20,
+                                        column: 14,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 13,
+                                Entry {
+                                    reference: {Node identifier (20, 4) - (20, 15)},
+                                    text: "n",
+                                    start_position: Point {
+                                        row: 20,
+                                        column: 14,
+                                    },
+                                    end_position: Point {
+                                        row: 20,
+                                        column: 15,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 14,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 14,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 15,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 15,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 16,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 16,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 17,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 64,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 5,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 42,
+                            entries: [
+                                Entry {
+                                    reference: {Node , (42, 19) - (42, 20)},
+                                    text: ",",
+                                    start_position: Point {
+                                        row: 42,
+                                        column: 19,
+                                    },
+                                    end_position: Point {
+                                        row: 42,
+                                        column: 20,
+                                    },
+                                    kind_id: 123,
                                 },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node . (64, 9) - (64, 10)},
-                                text: ".",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 10,
-                                },
-                                kind_id: 165,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 12,
-                                },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 13,
-                                },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "k",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 14,
-                                },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 65,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 66,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 5,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 12,
-                                },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 13,
-                                },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "k",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 14,
-                                },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-        ],
-    ),
-    Hunks(
-        [
-            Hunk(
-                [
-                    Line {
-                        line_index: 2,
-                        entries: [
-                            Entry {
-                                reference: {Node , (2, 26) - (2, 27)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 2,
-                                    column: 26,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 59,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (59, 4) - (59, 9)},
+                                    text: "b",
+                                    start_position: Point {
+                                        row: 59,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 59,
+                                        column: 5,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 2,
-                                    column: 27,
+                                Entry {
+                                    reference: {Node identifier (59, 4) - (59, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 59,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 59,
+                                        column: 6,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 123,
-                            },
-                        ],
-                    },
-                ],
+                                Entry {
+                                    reference: {Node identifier (59, 4) - (59, 9)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 59,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 59,
+                                        column: 7,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (59, 4) - (59, 9)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 59,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 59,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 20,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "_",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 12,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 53,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (53, 7) - (53, 11)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 53,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 53,
+                                        column: 8,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 13,
+                                Entry {
+                                    reference: {Node identifier (53, 7) - (53, 11)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 53,
+                                        column: 9,
+                                    },
+                                    end_position: Point {
+                                        row: 53,
+                                        column: 10,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "f",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 13,
+                                Entry {
+                                    reference: {Node identifier (53, 7) - (53, 11)},
+                                    text: "k",
+                                    start_position: Point {
+                                        row: 53,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 53,
+                                        column: 11,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 14,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 14,
-                                },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 15,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 42,
-                        entries: [
-                            Entry {
-                                reference: {Node , (42, 19) - (42, 20)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 42,
-                                    column: 19,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 61,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (61, 12) - (61, 17)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 61,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 61,
+                                        column: 13,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 42,
-                                    column: 20,
+                                Entry {
+                                    reference: {Node identifier (61, 12) - (61, 17)},
+                                    text: "o",
+                                    start_position: Point {
+                                        row: 61,
+                                        column: 13,
+                                    },
+                                    end_position: Point {
+                                        row: 61,
+                                        column: 14,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 123,
-                            },
-                        ],
-                    },
-                ],
+                                Entry {
+                                    reference: {Node identifier (61, 12) - (61, 17)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 61,
+                                        column: 14,
+                                    },
+                                    end_position: Point {
+                                        row: 61,
+                                        column: 15,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (61, 12) - (61, 17)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 61,
+                                        column: 15,
+                                    },
+                                    end_position: Point {
+                                        row: 61,
+                                        column: 16,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (61, 12) - (61, 17)},
+                                    text: "y",
+                                    start_position: Point {
+                                        row: 61,
+                                        column: 16,
+                                    },
+                                    end_position: Point {
+                                        row: 61,
+                                        column: 17,
+                                    },
+                                    kind_id: 1,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 59,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "b",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 4,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 67,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (67, 9) - (67, 11)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 67,
+                                        column: 9,
+                                    },
+                                    end_position: Point {
+                                        row: 67,
+                                        column: 10,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node identifier (67, 9) - (67, 11)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 67,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 67,
+                                        column: 11,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 67,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (67, 9) - (67, 11)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 9,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 70,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (70, 1) - (70, 3)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 1,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 2,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 10,
+                                Entry {
+                                    reference: {Node . (70, 3) - (70, 4)},
+                                    text: ".",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 3,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 4,
+                                    },
+                                    kind_id: 165,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (67, 9) - (67, 11)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 10,
+                                Entry {
+                                    reference: {Node field_identifier (70, 4) - (70, 9)},
+                                    text: "b",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 5,
+                                    },
+                                    kind_id: 368,
                                 },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 11,
+                                Entry {
+                                    reference: {Node field_identifier (70, 4) - (70, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 6,
+                                    },
+                                    kind_id: 368,
                                 },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                                Entry {
+                                    reference: {Node field_identifier (70, 4) - (70, 9)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 7,
+                                    },
+                                    kind_id: 368,
+                                },
+                                Entry {
+                                    reference: {Node field_identifier (70, 4) - (70, 9)},
+                                    text: "a",
+                                    start_position: Point {
+                                        row: 70,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 70,
+                                        column: 8,
+                                    },
+                                    kind_id: 368,
+                                },
+                            ],
+                        },
+                        Line {
+                            line_index: 71,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (71, 1) - (71, 3)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 71,
+                                        column: 1,
+                                    },
+                                    end_position: Point {
+                                        row: 71,
+                                        column: 2,
+                                    },
+                                    kind_id: 1,
+                                },
+                            ],
+                        },
+                        Line {
+                            line_index: 72,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (72, 1) - (72, 3)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 1,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 2,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (72, 1) - (72, 3)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 2,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 3,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node field_identifier (72, 4) - (72, 9)},
+                                    text: "b",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 5,
+                                    },
+                                    kind_id: 368,
+                                },
+                                Entry {
+                                    reference: {Node field_identifier (72, 4) - (72, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 6,
+                                    },
+                                    kind_id: 368,
+                                },
+                                Entry {
+                                    reference: {Node field_identifier (72, 4) - (72, 9)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 7,
+                                    },
+                                    kind_id: 368,
+                                },
+                                Entry {
+                                    reference: {Node field_identifier (72, 4) - (72, 9)},
+                                    text: "a",
+                                    start_position: Point {
+                                        row: 72,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 72,
+                                        column: 8,
+                                    },
+                                    kind_id: 368,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 70,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (70, 1) - (70, 3)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 1,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 64,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (64, 4) - (64, 9)},
+                                    text: "o",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 6,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 2,
+                                Entry {
+                                    reference: {Node identifier (64, 4) - (64, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 7,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node . (70, 3) - (70, 4)},
-                                text: ".",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 3,
+                                Entry {
+                                    reference: {Node identifier (64, 4) - (64, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 8,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 4,
+                                Entry {
+                                    reference: {Node identifier (64, 4) - (64, 9)},
+                                    text: "y",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 165,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "b",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 4,
+                                Entry {
+                                    reference: {Node . (64, 9) - (64, 10)},
+                                    text: ".",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 9,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 10,
+                                    },
+                                    kind_id: 165,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node field_identifier (64, 10) - (64, 14)},
+                                    text: "a",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 11,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 12,
+                                    },
+                                    kind_id: 368,
                                 },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node field_identifier (64, 10) - (64, 14)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 13,
+                                    },
+                                    kind_id: 368,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 6,
+                                Entry {
+                                    reference: {Node field_identifier (64, 10) - (64, 14)},
+                                    text: "k",
+                                    start_position: Point {
+                                        row: 64,
+                                        column: 13,
+                                    },
+                                    end_position: Point {
+                                        row: 64,
+                                        column: 14,
+                                    },
+                                    kind_id: 368,
                                 },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 6,
+                            ],
+                        },
+                        Line {
+                            line_index: 65,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (65, 4) - (65, 9)},
+                                    text: "o",
+                                    start_position: Point {
+                                        row: 65,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 65,
+                                        column: 6,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 7,
+                                Entry {
+                                    reference: {Node identifier (65, 4) - (65, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 65,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 65,
+                                        column: 7,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 7,
+                                Entry {
+                                    reference: {Node identifier (65, 4) - (65, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 65,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 65,
+                                        column: 8,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 8,
+                                Entry {
+                                    reference: {Node identifier (65, 4) - (65, 9)},
+                                    text: "y",
+                                    start_position: Point {
+                                        row: 65,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 65,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 71,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (71, 1) - (71, 3)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 71,
-                                    column: 1,
+                            ],
+                        },
+                        Line {
+                            line_index: 66,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (66, 4) - (66, 9)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 5,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 71,
-                                    column: 2,
+                                Entry {
+                                    reference: {Node identifier (66, 4) - (66, 9)},
+                                    text: "o",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 6,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 72,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (72, 1) - (72, 3)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 1,
+                                Entry {
+                                    reference: {Node identifier (66, 4) - (66, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 7,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 2,
+                                Entry {
+                                    reference: {Node identifier (66, 4) - (66, 9)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 8,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (72, 1) - (72, 3)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 2,
+                                Entry {
+                                    reference: {Node identifier (66, 4) - (66, 9)},
+                                    text: "y",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 3,
+                                Entry {
+                                    reference: {Node field_identifier (66, 10) - (66, 14)},
+                                    text: "a",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 11,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 12,
+                                    },
+                                    kind_id: 368,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "b",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 4,
+                                Entry {
+                                    reference: {Node field_identifier (66, 10) - (66, 14)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 13,
+                                    },
+                                    kind_id: 368,
                                 },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node field_identifier (66, 10) - (66, 14)},
+                                    text: "k",
+                                    start_position: Point {
+                                        row: 66,
+                                        column: 13,
+                                    },
+                                    end_position: Point {
+                                        row: 66,
+                                        column: 14,
+                                    },
+                                    kind_id: 368,
                                 },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 6,
-                                },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 7,
-                                },
-                                kind_id: 368,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 8,
-                                },
-                                kind_id: 368,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
         ],
     ),

--- a/src/snapshots/diffsitter__tests__short_python_true.snap
+++ b/src/snapshots/diffsitter__tests__short_python_true.snap
@@ -2,155 +2,158 @@
 source: src/main.rs
 expression: diff_hunks
 ---
-(
-    Hunks(
-        [],
-    ),
-    Hunks(
+Ok(
+    RichHunks(
         [
-            Hunk(
-                [
-                    Line {
-                        line_index: 1,
-                        entries: [
-                            Entry {
-                                reference: {Node " (1, 4) - (1, 7)},
-                                text: "\"",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 4,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 1,
+                            entries: [
+                                Entry {
+                                    reference: {Node " (1, 4) - (1, 7)},
+                                    text: "\"",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 5,
+                                    },
+                                    kind_id: 102,
                                 },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node " (1, 4) - (1, 7)},
+                                    text: "\"",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 6,
+                                    },
+                                    kind_id: 102,
                                 },
-                                kind_id: 102,
-                            },
-                            Entry {
-                                reference: {Node " (1, 4) - (1, 7)},
-                                text: "\"",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node " (1, 4) - (1, 7)},
+                                    text: "\"",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 7,
+                                    },
+                                    kind_id: 102,
                                 },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 6,
-                                },
-                                kind_id: 102,
-                            },
-                            Entry {
-                                reference: {Node " (1, 4) - (1, 7)},
-                                text: "\"",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 7,
-                                },
-                                kind_id: 102,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 3,
-                        entries: [
-                            Entry {
-                                reference: {Node " (3, 4) - (3, 7)},
-                                text: "\"",
-                                start_position: Point {
-                                    row: 3,
-                                    column: 4,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 3,
+                            entries: [
+                                Entry {
+                                    reference: {Node " (3, 4) - (3, 7)},
+                                    text: "\"",
+                                    start_position: Point {
+                                        row: 3,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 3,
+                                        column: 5,
+                                    },
+                                    kind_id: 102,
                                 },
-                                end_position: Point {
-                                    row: 3,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node " (3, 4) - (3, 7)},
+                                    text: "\"",
+                                    start_position: Point {
+                                        row: 3,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 3,
+                                        column: 6,
+                                    },
+                                    kind_id: 102,
                                 },
-                                kind_id: 102,
-                            },
-                            Entry {
-                                reference: {Node " (3, 4) - (3, 7)},
-                                text: "\"",
-                                start_position: Point {
-                                    row: 3,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node " (3, 4) - (3, 7)},
+                                    text: "\"",
+                                    start_position: Point {
+                                        row: 3,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 3,
+                                        column: 7,
+                                    },
+                                    kind_id: 102,
                                 },
-                                end_position: Point {
-                                    row: 3,
-                                    column: 6,
-                                },
-                                kind_id: 102,
-                            },
-                            Entry {
-                                reference: {Node " (3, 4) - (3, 7)},
-                                text: "\"",
-                                start_position: Point {
-                                    row: 3,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 3,
-                                    column: 7,
-                                },
-                                kind_id: 102,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 6,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (6, 4) - (6, 5)},
-                                text: "x",
-                                start_position: Point {
-                                    row: 6,
-                                    column: 4,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 6,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (6, 4) - (6, 5)},
+                                    text: "x",
+                                    start_position: Point {
+                                        row: 6,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 6,
+                                        column: 5,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 6,
-                                    column: 5,
+                                Entry {
+                                    reference: {Node = (6, 10) - (6, 11)},
+                                    text: "=",
+                                    start_position: Point {
+                                        row: 6,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 6,
+                                        column: 11,
+                                    },
+                                    kind_id: 46,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node = (6, 10) - (6, 11)},
-                                text: "=",
-                                start_position: Point {
-                                    row: 6,
-                                    column: 10,
+                                Entry {
+                                    reference: {Node integer (6, 12) - (6, 13)},
+                                    text: "1",
+                                    start_position: Point {
+                                        row: 6,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 6,
+                                        column: 13,
+                                    },
+                                    kind_id: 92,
                                 },
-                                end_position: Point {
-                                    row: 6,
-                                    column: 11,
-                                },
-                                kind_id: 46,
-                            },
-                            Entry {
-                                reference: {Node integer (6, 12) - (6, 13)},
-                                text: "1",
-                                start_position: Point {
-                                    row: 6,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 6,
-                                    column: 13,
-                                },
-                                kind_id: 92,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
         ],
     ),

--- a/src/snapshots/diffsitter__tests__short_rust_true.snap
+++ b/src/snapshots/diffsitter__tests__short_rust_true.snap
@@ -2,408 +2,414 @@
 source: src/main.rs
 expression: diff_hunks
 ---
-(
-    Hunks(
+Ok(
+    RichHunks(
         [
-            Hunk(
-                [
-                    Line {
-                        line_index: 1,
-                        entries: [
-                            Entry {
-                                reference: {Node let (1, 4) - (1, 7)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 4,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 9,
+                            entries: [
+                                Entry {
+                                    reference: {Node } (9, 0) - (9, 1)},
+                                    text: "}",
+                                    start_position: Point {
+                                        row: 9,
+                                        column: 0,
+                                    },
+                                    end_position: Point {
+                                        row: 9,
+                                        column: 1,
+                                    },
+                                    kind_id: 7,
                                 },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 5,
-                                },
-                                kind_id: 61,
-                            },
-                            Entry {
-                                reference: {Node let (1, 4) - (1, 7)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 6,
-                                },
-                                kind_id: 61,
-                            },
-                            Entry {
-                                reference: {Node let (1, 4) - (1, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 7,
-                                },
-                                kind_id: 61,
-                            },
-                            Entry {
-                                reference: {Node identifier (1, 8) - (1, 9)},
-                                text: "x",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node = (1, 10) - (1, 11)},
-                                text: "=",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 11,
-                                },
-                                kind_id: 78,
-                            },
-                            Entry {
-                                reference: {Node integer_literal (1, 12) - (1, 13)},
-                                text: "1",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 13,
-                                },
-                                kind_id: 167,
-                            },
-                            Entry {
-                                reference: {Node ; (1, 13) - (1, 14)},
-                                text: ";",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 14,
-                                },
-                                kind_id: 2,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 4,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (4, 3) - (4, 10)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 4,
-                                    column: 8,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 11,
+                            entries: [
+                                Entry {
+                                    reference: {Node fn (11, 0) - (11, 2)},
+                                    text: "f",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 0,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 1,
+                                    },
+                                    kind_id: 57,
                                 },
-                                end_position: Point {
-                                    row: 4,
-                                    column: 9,
+                                Entry {
+                                    reference: {Node fn (11, 0) - (11, 2)},
+                                    text: "n",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 1,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 2,
+                                    },
+                                    kind_id: 57,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (4, 3) - (4, 10)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 4,
-                                    column: 9,
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "a",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 3,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 4,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 4,
-                                    column: 10,
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 5,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "d",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 6,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 7,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 8,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "i",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "o",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 9,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 10,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node identifier (11, 3) - (11, 11)},
+                                    text: "n",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 11,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node ( (11, 11) - (11, 12)},
+                                    text: "(",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 11,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 12,
+                                    },
+                                    kind_id: 4,
+                                },
+                                Entry {
+                                    reference: {Node ) (11, 12) - (11, 13)},
+                                    text: ")",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 13,
+                                    },
+                                    kind_id: 5,
+                                },
+                                Entry {
+                                    reference: {Node { (11, 14) - (11, 15)},
+                                    text: "{",
+                                    start_position: Point {
+                                        row: 11,
+                                        column: 14,
+                                    },
+                                    end_position: Point {
+                                        row: 11,
+                                        column: 15,
+                                    },
+                                    kind_id: 6,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
-        ],
-    ),
-    Hunks(
-        [
-            Hunk(
-                [
-                    Line {
-                        line_index: 9,
-                        entries: [
-                            Entry {
-                                reference: {Node } (9, 0) - (9, 1)},
-                                text: "}",
-                                start_position: Point {
-                                    row: 9,
-                                    column: 0,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 1,
+                            entries: [
+                                Entry {
+                                    reference: {Node let (1, 4) - (1, 7)},
+                                    text: "l",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 4,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 5,
+                                    },
+                                    kind_id: 61,
                                 },
-                                end_position: Point {
-                                    row: 9,
-                                    column: 1,
+                                Entry {
+                                    reference: {Node let (1, 4) - (1, 7)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 5,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 6,
+                                    },
+                                    kind_id: 61,
                                 },
-                                kind_id: 7,
-                            },
-                        ],
-                    },
-                ],
+                                Entry {
+                                    reference: {Node let (1, 4) - (1, 7)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 6,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 7,
+                                    },
+                                    kind_id: 61,
+                                },
+                                Entry {
+                                    reference: {Node identifier (1, 8) - (1, 9)},
+                                    text: "x",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
+                                },
+                                Entry {
+                                    reference: {Node = (1, 10) - (1, 11)},
+                                    text: "=",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 11,
+                                    },
+                                    kind_id: 78,
+                                },
+                                Entry {
+                                    reference: {Node integer_literal (1, 12) - (1, 13)},
+                                    text: "1",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 12,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 13,
+                                    },
+                                    kind_id: 167,
+                                },
+                                Entry {
+                                    reference: {Node ; (1, 13) - (1, 14)},
+                                    text: ";",
+                                    start_position: Point {
+                                        row: 1,
+                                        column: 13,
+                                    },
+                                    end_position: Point {
+                                        row: 1,
+                                        column: 14,
+                                    },
+                                    kind_id: 2,
+                                },
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 11,
-                        entries: [
-                            Entry {
-                                reference: {Node fn (11, 0) - (11, 2)},
-                                text: "f",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 0,
+            New(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 14,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (14, 3) - (14, 10)},
+                                    text: "t",
+                                    start_position: Point {
+                                        row: 14,
+                                        column: 7,
+                                    },
+                                    end_position: Point {
+                                        row: 14,
+                                        column: 8,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 1,
+                                Entry {
+                                    reference: {Node identifier (14, 3) - (14, 10)},
+                                    text: "w",
+                                    start_position: Point {
+                                        row: 14,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 14,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 57,
-                            },
-                            Entry {
-                                reference: {Node fn (11, 0) - (11, 2)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 1,
+                                Entry {
+                                    reference: {Node ( (14, 10) - (14, 11)},
+                                    text: "(",
+                                    start_position: Point {
+                                        row: 14,
+                                        column: 10,
+                                    },
+                                    end_position: Point {
+                                        row: 14,
+                                        column: 11,
+                                    },
+                                    kind_id: 4,
                                 },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 2,
+                                Entry {
+                                    reference: {Node ) (14, 11) - (14, 12)},
+                                    text: ")",
+                                    start_position: Point {
+                                        row: 14,
+                                        column: 11,
+                                    },
+                                    end_position: Point {
+                                        row: 14,
+                                        column: 12,
+                                    },
+                                    kind_id: 5,
                                 },
-                                kind_id: 57,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 3,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 5,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 10,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 11,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node ( (11, 11) - (11, 12)},
-                                text: "(",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 12,
-                                },
-                                kind_id: 4,
-                            },
-                            Entry {
-                                reference: {Node ) (11, 12) - (11, 13)},
-                                text: ")",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 13,
-                                },
-                                kind_id: 5,
-                            },
-                            Entry {
-                                reference: {Node { (11, 14) - (11, 15)},
-                                text: "{",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 14,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 15,
-                                },
-                                kind_id: 6,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
-            Hunk(
-                [
-                    Line {
-                        line_index: 14,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (14, 3) - (14, 10)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 7,
+            Old(
+                Hunk(
+                    [
+                        Line {
+                            line_index: 4,
+                            entries: [
+                                Entry {
+                                    reference: {Node identifier (4, 3) - (4, 10)},
+                                    text: "n",
+                                    start_position: Point {
+                                        row: 4,
+                                        column: 8,
+                                    },
+                                    end_position: Point {
+                                        row: 4,
+                                        column: 9,
+                                    },
+                                    kind_id: 1,
                                 },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 8,
+                                Entry {
+                                    reference: {Node identifier (4, 3) - (4, 10)},
+                                    text: "e",
+                                    start_position: Point {
+                                        row: 4,
+                                        column: 9,
+                                    },
+                                    end_position: Point {
+                                        row: 4,
+                                        column: 10,
+                                    },
+                                    kind_id: 1,
                                 },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (14, 3) - (14, 10)},
-                                text: "w",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node ( (14, 10) - (14, 11)},
-                                text: "(",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 11,
-                                },
-                                kind_id: 4,
-                            },
-                            Entry {
-                                reference: {Node ) (14, 11) - (14, 12)},
-                                text: ")",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 12,
-                                },
-                                kind_id: 5,
-                            },
-                        ],
-                    },
-                ],
+                            ],
+                        },
+                    ],
+                ),
             ),
         ],
     ),


### PR DESCRIPTION
This updates some the logic for aggregating hunks so we can preserve
better ordering around diff hunks.

Before, we would compute the edit script and then split the entries into
their old/new respectively, and then coalesce them into hunks. When
displaying these hunks, we would maintain a pointer to the current
position of the hunks in each document, and then display whichever hunk
had a lower starting line.

This was suboptimal because we ended up losing location information from
the edit script.

We have updated the logic for coalescing hunks to better respect the
original order of the edit script. Now we iterate through the edit
script in order, without doing any preprocessing or splitting based on
the document source. We will aggregate edit entries that are in adjacent
lines, but we are going in the order of the original edit script.

This also cleans up some old unused code in the diff module and adds
some performance improvements by doing unchecked vector indexing in
scenarios where we already check the indices.
