### PR TITLE
chore: Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,6 @@ dependencies = [
  "libloading",
  "log",
  "logging_timer",
- "paw",
  "phf",
  "pretty_assertions",
  "pretty_env_logger",
@@ -845,33 +844,6 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "paw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c0fc9b564dbc3dc2ed7c92c0c144f4de340aa94514ce2b446065417c4084e9"
-dependencies = [
- "paw-attributes",
- "paw-raw",
-]
-
-[[package]]
-name = "paw-attributes"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f35583365be5d148e959284f42526841917b7bfa09e2d1a7ad5dde2cf0eaa39"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "paw-raw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0b59668fe80c5afe998f0c0bf93322bf2cd66cafeeb80581f291716f3467f2"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ clap_complete = "3.1.1"
 anyhow = "1.0.56"
 phf = { version = "0.10.1", features = ["macros"] }
 console = "0.15.0"
-paw = "1.0.0"
 strum = { version = "0.24.0", features = ["derive"] }
 strum_macros = "0.24.0"
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
`cargo-machete` showed that `paw` isn't being used in this project, but
we build with it anyways.
