### PR TITLE
fix: Fix compilation error with dynamic grammars

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod input_processing;
 mod neg_idx_vec;
 mod parse;
 
+#[cfg(feature = "static-grammar-libs")]
 use crate::parse::supported_languages;
 use anyhow::Result;
 use clap::IntoApp;


### PR DESCRIPTION
This corrects a build error that occurred if `static-grammar-libs` was
not selected. Fixes #342.
