### PR TITLE
Revert "build(deps): bump test-case from 2.0.2 to 2.1.0 (#350)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,18 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "test-case"
-version = "2.1.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196e8a70562e252cc51eaaaee3ecddc39803d9b7fd4a772b7c7dae7cdf42a859"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd461f47ade621665c9f4e44b20449341769911c253275dc5cb03726cbb852c"
+checksum = "6344589a99d3971d6fa4e8314dbcbeca2df6273a6b642e46906971779159af1f"
 dependencies = [
  "cfg-if",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ libloading = "0.7.3"
 unicode-segmentation = "1.9.0"
 
 [dev-dependencies]
-test-case = "2.1.0"
+test-case = "2.0.2"
 pretty_assertions = "1.2.1"
 
 # We need the backtrace feature to enable snapshot name generation in


### PR DESCRIPTION
This reverts commit 129ed9aa527e6fd22434913293c2546f30d4a01f.

We are reverting because this is the last commit where everything in the CI/CD
pipeline was green.
