### PR TITLE
feat: Derive `Eq` on structs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ use directories_next::ProjectDirs;
 const CFG_FILE_NAME: &str = "config.json5";
 
 /// The config struct for the application
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// Custom file extension mappings between a file extension and a language

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -67,7 +67,7 @@ fn common_suffix_len<T: PartialEq>(
 }
 
 /// The edit information representing a line
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Line<'a> {
     /// The index of the line in the original document
     pub line_index: usize,
@@ -87,7 +87,7 @@ impl<'a> Line<'a> {
 /// A grouping of consecutive edit lines for a document
 ///
 /// Every line in a hunk must be consecutive and in ascending order.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Hunk<'a>(pub Vec<Line<'a>>);
 
 /// Types of errors that come up when inserting an entry to a hunk
@@ -198,7 +198,7 @@ impl<'a> Hunk<'a> {
 ///
 /// A lot of items in the diff are delineated by whether they come from the old document or the new
 /// one. This enum generically defines an enum wrapper over those document types.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DocumentType<T: Debug + Clone + PartialEq> {
     Old(T),
     New(T),

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -127,7 +127,7 @@ impl From<&Config> for EmphasizedStyle {
 /// A writer that can render a diff to a terminal
 ///
 /// This struct contains the formatting options for the diff
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct DiffWriter {
     /// The formatting options to use with text addition
@@ -171,7 +171,7 @@ pub struct DisplayParameters<'a> {
 }
 
 /// The parameters required to display a diff for a particular document
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DocumentDiffData<'a> {
     /// The filename of the document
     pub filename: &'a str,
@@ -414,7 +414,7 @@ impl DiffWriter {
 /// The formatting directives to use with emphasized text in the line of a diff
 ///
 /// `Bold` is used as the default emphasis strategy between two lines.
-#[derive(Debug, PartialEq, EnumString, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, EnumString, Serialize, Deserialize)]
 #[strum(serialize_all = "snake_case")]
 pub enum Emphasis {
     /// Don't emphasize anything
@@ -438,7 +438,7 @@ impl Default for Emphasis {
 
 /// The colors to use when highlighting additions and deletions
 // TODO(afnan) implement the proper defaults for this struct
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HighlightColors {
     /// The background color to use with an addition
     #[serde(with = "ColorDef")]

--- a/src/input_processing.rs
+++ b/src/input_processing.rs
@@ -62,7 +62,7 @@ fn from_ts_tree<'a>(tree: &'a TSTree, text: &'a str) -> Vector<'a> {
 /// The leaves of an AST vector
 ///
 /// This is used as an intermediate struct for flattening the tree structure.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VectorLeaf<'a> {
     pub reference: TSNode<'a>,
     pub text: &'a str,


### PR DESCRIPTION
This addresses a clippy lint and derives the `Eq` trait for various
structs as suggested by clippy.

This was done with:

```sh
cargo clippy --fix
```
