### PR TITLE
fix(console): Set stdout and stderr color policy

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
+use crate::console_utils::ColorOutputPolicy;
 use clap::Parser;
 use std::path::PathBuf;
-use strum_macros::{Display, EnumString};
+use strum_macros::EnumString;
 
 #[derive(Debug, Eq, PartialEq, Clone, Parser)]
 #[clap(author, version, about)]
@@ -115,22 +116,4 @@ pub enum Command {
         /// This will print the shell completion script to stdout. bash, zsh, and fish are supported.
         shell: ShellWrapper,
     },
-}
-
-/// Whether the output to the terminal should be colored
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, Display)]
-#[strum(serialize_all = "snake_case")]
-pub enum ColorOutputPolicy {
-    /// Automatically enable color if printing to a TTY, otherwise disable color
-    Auto,
-    /// Force plaintext output
-    Off,
-    /// Force color output
-    On,
-}
-
-impl Default for ColorOutputPolicy {
-    fn default() -> Self {
-        ColorOutputPolicy::Auto
-    }
 }

--- a/src/console_utils.rs
+++ b/src/console_utils.rs
@@ -1,0 +1,38 @@
+//! Helper functions for dealing with the terminal
+
+use console::{set_colors_enabled, set_colors_enabled_stderr};
+use strum::{Display, EnumString};
+
+/// Whether the output to the terminal should be colored
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum ColorOutputPolicy {
+    /// Automatically enable color if printing to a TTY, otherwise disable color
+    Auto,
+    /// Force plaintext output
+    Off,
+    /// Force color output
+    On,
+}
+
+impl Default for ColorOutputPolicy {
+    fn default() -> Self {
+        ColorOutputPolicy::Auto
+    }
+}
+
+/// Set terminal color settings based on the output policy.
+pub fn set_term_colors(setting: ColorOutputPolicy) {
+    if setting == ColorOutputPolicy::Auto {
+        return;
+    }
+    let colors_enabled = match setting {
+        ColorOutputPolicy::On => true,
+        ColorOutputPolicy::Off => false,
+        ColorOutputPolicy::Auto => {
+            panic!("Color output policy is auto, this case should have been already handled")
+        }
+    };
+    set_colors_enabled(colors_enabled);
+    set_colors_enabled_stderr(colors_enabled);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod config;
+mod console_utils;
 mod diff;
 mod formatting;
 mod input_processing;
@@ -8,12 +9,12 @@ mod parse;
 
 #[cfg(feature = "static-grammar-libs")]
 use crate::parse::supported_languages;
+use ::console::Term;
 use anyhow::Result;
 use clap::FromArgMatches;
 use clap::IntoApp;
-use cli::{Args, ColorOutputPolicy};
+use cli::Args;
 use config::{Config, ReadError};
-use console::Term;
 use formatting::{DisplayParameters, DocumentDiffData};
 use human_panic::setup_panic;
 use input_processing::VectorData;
@@ -215,17 +216,6 @@ pub fn list_supported_languages() {
     }
 }
 
-/// Set whether the terminal should display colors based on the user's preferences
-///
-/// This method will set the terminal output policy *for the current thread*.
-fn set_term_colors(color_opt: ColorOutputPolicy) {
-    match color_opt {
-        ColorOutputPolicy::Off => console::set_colors_enabled(false),
-        ColorOutputPolicy::On => console::set_colors_enabled(true),
-        ColorOutputPolicy::Auto => (),
-    };
-}
-
 /// Print shell completion scripts to `stdout`.
 ///
 /// This is a basic wrapper for the subcommand.
@@ -275,7 +265,7 @@ fn main() -> Result<()> {
         pretty_env_logger::formatted_timed_builder()
             .filter_level(log_level)
             .init();
-        set_term_colors(args.color_output);
+        console_utils::set_term_colors(args.color_output);
         // First check if the input files can be parsed with tree-sitter.
         let files_supported = are_input_files_supported(&args, &config);
 


### PR DESCRIPTION
We were only setting the color output policy for `stdout` before. This
updates the code to set the color policy for stderr as well. This also
splits out the console utils into a separate module.
