### PR TITLE
feat(output): Implement modular rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -60,9 +60,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "cargo-emit"
@@ -128,7 +128,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size 0.2.2",
+ "terminal_size 0.2.3",
  "unicase",
  "unicode-width",
 ]
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -321,15 +321,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -353,6 +353,8 @@ dependencies = [
  "clap_complete",
  "console",
  "directories-next",
+ "enum-iterator",
+ "enum_dispatch",
  "human-panic",
  "insta",
  "jemallocator",
@@ -365,6 +367,7 @@ dependencies = [
  "pretty_env_logger",
  "rayon",
  "serde",
+ "serde-value",
  "serde_json",
  "shadow-rs",
  "strum",
@@ -378,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -438,6 +441,38 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "enum-iterator"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -500,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -511,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "git2"
@@ -625,15 +660,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
  "windows-sys",
@@ -646,8 +675,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
 dependencies = [
  "hermit-abi 0.2.6",
- "io-lifetimes 1.0.2",
- "rustix 0.36.4",
+ "io-lifetimes",
+ "rustix",
  "windows-sys",
 ]
 
@@ -665,9 +694,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.5.1+5.3.0-patched"
+version = "0.5.2+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2b313609b95939cb0c5a5c6917fb9b7c9394562aa3ef44eb66ffa51736432"
+checksum = "134163979b6eed9564c98637b710b40979939ba351f59952708234ea11b5f3f8"
 dependencies = [
  "cc",
  "fs_extra",
@@ -761,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -776,15 +805,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -834,11 +857,20 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -862,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
 dependencies = [
  "memchr",
 ]
@@ -876,16 +908,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.3.1"
+name = "ordered-float"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "os_type"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3df761f6470298359f84fcfb60d86db02acc22c251c37265c07a3d1057d2389"
+checksum = "e24d44c0eea30167516ed8f6daca4b5e3eebcde1bde1e4e6e08b809fb02c7ba5"
 dependencies = [
  "regex",
 ]
@@ -907,9 +948,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.3.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -917,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
 dependencies = [
  "pest",
  "pest_generator",
@@ -927,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -940,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
 dependencies = [
  "once_cell",
  "pest",
@@ -1126,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1137,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustc-demangle"
@@ -1149,37 +1190,23 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 0.7.5",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.0.46",
- "windows-sys",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 1.0.2",
- "libc",
- "linux-raw-sys 0.1.3",
+ "linux-raw-sys",
  "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
@@ -1195,9 +1222,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "serde"
@@ -1206,6 +1233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -1326,11 +1363,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
+checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
- "rustix 0.35.13",
+ "rustix",
  "windows-sys",
 ]
 
@@ -1345,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "test-case-macros"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95968eedc6fc4f5c21920e0f4264f78ec5e4c56bb394f319becc1a5830b3e54"
+checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
 dependencies = [
  "cfg-if",
  "proc-macro-error",
@@ -1422,9 +1459,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -1441,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "tz-rs"
@@ -1456,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "tzdb"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d925691b01568bcf38f91fd951cc710c92b965d299c90face12e6bc74883ba5c"
+checksum = "12cf8bd66b64b0801ee3faac2b86a657d4ddbb345efa9bb6a18d626693d9c2de"
 dependencies = [
  "iana-time-zone",
  "tz-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ libloading = "0.7.4"
 unicode-segmentation = "1.10.0"
 human-panic = "1.0.3"
 shadow-rs = { version = "0.19.0", optional = true }
+enum_dispatch = "0.3.8"
+serde-value = "0.7.0"
+enum-iterator = "1.2.0"
 
 [dev-dependencies]
 test-case = "2.2.2"

--- a/assets/sample_config.json5
+++ b/assets/sample_config.json5
@@ -7,34 +7,72 @@
 {
     // Set options for terminal formatting here
     "formatting": {
-        // Set the style for diff hunks from the new document
-        "addition": {
-            // The color of the highlight around emphasized added text
-            "highlight": null,
-            // The foreground color for regular text
-            "regular-foreground": "green",
-            // The foreground color for emphasized text
-            // Note that colors can either be a string or a 256 bit color value
-            "emphasized-foreground": {
-                "color256": 0,
-            },
-            // Whether emphasized text should be bolded
-            "bold": true,
-            // Whether emphasized text should be underlined
-            "underline": false,
-            // The prefix string prepend to the contents of the diff hunk, for
-            // an addition hunk
-            "prefix": "+",
+        "unified": {
+          // Set the style for diff hunks from the new document
+          "addition": {
+              // The color of the highlight around emphasized added text
+              "highlight": null,
+              // The foreground color for regular text
+              "regular-foreground": "green",
+              // The foreground color for emphasized text
+              // Note that colors can either be a string or a 256 bit color value
+              "emphasized-foreground": {
+                  "color256": 0,
+              },
+              // Whether emphasized text should be bolded
+              "bold": true,
+              // Whether emphasized text should be underlined
+              "underline": false,
+              // The prefix string prepend to the contents of the diff hunk, for
+              // an addition hunk
+              "prefix": "+",
+          },
+          // Set the style for diff hunks from the old document
+          // These are the same as the options for "addition", the only
+          // difference is that they apply to the deletion hunks
+          "deletion": {
+              "regular-foreground": "red",
+              "emphasized-foreground": "red",
+              "bold": true,
+              "underline": false,
+              "prefix": "-",
+          },
         },
-        // Set the style for diff hunks from the old document
-        // These are the same as the options for "addition", the only
-        // difference is that they apply to the deletion hunks
-        "deletion": {
-            "regular-foreground": "red",
-            "emphasized-foreground": "red",
-            "bold": true,
-            "underline": false,
-            "prefix": "-",
+        // We can also define custom render modes which are defined as a
+        // key-value mapping of tags to rendering configs.
+        "custom": {
+          "custom_render_mode": {
+            "type": "unified",
+            // Set the style for diff hunks from the new document
+            "addition": {
+                // The color of the highlight around emphasized added text
+                "highlight": null,
+                // The foreground color for regular text
+                "regular-foreground": "green",
+                // The foreground color for emphasized text
+                // Note that colors can either be a string or a 256 bit color value
+                "emphasized-foreground": {
+                    "color256": 0,
+                },
+                // Whether emphasized text should be bolded
+                "bold": true,
+                // Whether emphasized text should be underlined
+                "underline": false,
+                // The prefix string prepend to the contents of the diff hunk, for
+                // an addition hunk
+                "prefix": "+",
+            },
+            // Set the style for diff hunks from the old document
+            // These are the same as the options for "addition", the only
+            // difference is that they apply to the deletion hunks
+            "deletion": {
+                "regular-foreground": "red",
+                "emphasized-foreground": "red",
+                "bold": true,
+                "underline": false,
+                "prefix": "-",
+            },
+          },
         },
     },
     // Set options related to grammars here

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,12 @@ pub struct Args {
     /// default settings.
     #[clap(short, long)]
     pub no_config: bool,
+
+    /// Specify which renderer tag to use.
+    ///
+    /// If no option is supplied then this will fall back to the default renderer.
+    #[clap(short, long)]
+    pub renderer: Option<String>,
 }
 
 /// A wrapper struct for `clap_complete::Shell`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Utilities and definitions for config handling
 
 use crate::input_processing::TreeSitterProcessor;
-use crate::{formatting::DiffWriter, parse::GrammarConfig};
+use crate::{parse::GrammarConfig, render::RenderConfig};
 use anyhow::{Context, Result};
 use json5 as json;
 use log::info;
@@ -31,7 +31,7 @@ pub struct Config {
     pub file_associations: Option<HashMap<String, String>>,
 
     /// Formatting options for display
-    pub formatting: DiffWriter,
+    pub formatting: RenderConfig,
 
     /// Options for loading
     pub grammar: GrammarConfig,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,299 @@
+//! Utilities and modules related to rendering diff outputs.
+//!
+//! We have a modular system for displaying diff data to the terminal. Using this system makes it
+//! much easier to extend with new formats that people may request.
+//!
+//! This library defines a fairly minimal interface for renderers: a single trait called
+//! `Renderer`. From there implementers are free to do whatever they want with the diff data.
+//!
+//! This module also defines utilities that may be useful for `Renderer` implementations.
+
+mod unified;
+
+use crate::diff::RichHunks;
+use console::Term;
+use console::{Color, Style};
+use enum_dispatch::enum_dispatch;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::BufWriter;
+use strum::{self, Display, EnumIter, EnumString};
+use unified::Unified;
+
+/// The parameters required to display a diff for a particular document
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentDiffData<'a> {
+    /// The filename of the document
+    pub filename: &'a str,
+    /// The full text of the document
+    pub text: &'a str,
+}
+
+/// The parameters a [Renderer] instance receives to render a diff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisplayData<'a> {
+    /// The hunks constituting the diff.
+    pub hunks: RichHunks<'a>,
+    /// The parameters that correspond to the old document
+    pub old: DocumentDiffData<'a>,
+    /// The parameters that correspond to the new document
+    pub new: DocumentDiffData<'a>,
+}
+
+/// A buffered writer for a [terminal](Term) object.
+type TermWriter = BufWriter<Term>;
+
+#[enum_dispatch]
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, Display, EnumIter, EnumString)]
+#[strum(serialize_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Renderers {
+    Unified,
+}
+
+impl Default for Renderers {
+    fn default() -> Self {
+        Renderers::Unified(Unified::default())
+    }
+}
+
+/// An interface that renders given diff data.
+#[enum_dispatch(Renderers)]
+pub trait Renderer {
+    /// Render a diff.
+    ///
+    /// We use anyhow for errors so errors are free form for implementors, as they are not
+    /// recoverable.
+    fn render(&self, writer: &mut TermWriter, data: &DisplayData) -> anyhow::Result<()>;
+}
+
+/// A copy of the [Color](console::Color) enum so we can serialize using serde, and get around the
+/// orphan rule.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+#[serde(remote = "Color", rename_all = "snake_case")]
+enum ColorDef {
+    Color256(u8),
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+}
+
+impl From<ColorDef> for Color {
+    fn from(c: ColorDef) -> Self {
+        match c {
+            ColorDef::Black => Color::Black,
+            ColorDef::White => Color::White,
+            ColorDef::Red => Color::Red,
+            ColorDef::Green => Color::Green,
+            ColorDef::Yellow => Color::Yellow,
+            ColorDef::Blue => Color::Blue,
+            ColorDef::Magenta => Color::Magenta,
+            ColorDef::Cyan => Color::Cyan,
+            ColorDef::Color256(c) => Color::Color256(c),
+        }
+    }
+}
+
+impl Default for ColorDef {
+    fn default() -> Self {
+        ColorDef::Black
+    }
+}
+
+/// Workaround so we can use the `ColorDef` remote serialization mechanism with optional types
+mod opt_color_def {
+    use super::{Color, ColorDef};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn serialize<S>(value: &Option<Color>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a>(#[serde(with = "ColorDef")] &'a Color);
+
+        value.as_ref().map(Helper).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Color>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper(#[serde(with = "ColorDef")] Color);
+
+        let helper = Option::deserialize(deserializer)?;
+        Ok(helper.map(|Helper(external)| external))
+    }
+}
+
+/// A helper function for the serde serializer
+///
+/// Due to the shenanigans we're using to serialize the optional color, we need to supply this
+/// method so serde can infer a default value for an option when its key is missing.
+fn default_option<T>() -> Option<T> {
+    None
+}
+
+/// The style that applies to regular text in a diff
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RegularStyle(Style);
+
+/// The style that applies to emphasized text in a diff
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EmphasizedStyle(Style);
+
+/// The formatting directives to use with emphasized text in the line of a diff
+///
+/// `Bold` is used as the default emphasis strategy between two lines.
+#[derive(Debug, PartialEq, EnumString, Serialize, Deserialize, Eq)]
+#[strum(serialize_all = "snake_case")]
+pub enum Emphasis {
+    /// Don't emphasize anything
+    ///
+    /// This field exists because the absence of a value implies that the user wants to use the
+    /// default emphasis strategy.
+    None,
+    /// Bold the differences between the two lines for emphasis
+    Bold,
+    /// Underline the differences between two lines for emphasis
+    Underline,
+    /// Use a colored highlight for emphasis
+    Highlight(HighlightColors),
+}
+
+impl Default for Emphasis {
+    fn default() -> Self {
+        Emphasis::Bold
+    }
+}
+
+/// The colors to use when highlighting additions and deletions
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HighlightColors {
+    /// The background color to use with an addition
+    #[serde(with = "ColorDef")]
+    pub addition: Color,
+    /// The background color to use with a deletion
+    #[serde(with = "ColorDef")]
+    pub deletion: Color,
+}
+
+impl Default for HighlightColors {
+    fn default() -> Self {
+        HighlightColors {
+            addition: Color::Color256(0),
+            deletion: Color::Color256(0),
+        }
+    }
+}
+
+/// Configurations and templates for different configuration aliases
+///
+/// The user can define settings for each renderer as well as custom tags for different renderer
+/// configurations.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case", default)]
+pub struct RenderConfig {
+    /// The default diff renderer to use.
+    ///
+    /// This is used if no renderer is specified at the command line.
+    default: String,
+
+    unified: unified::Unified,
+
+    /// A mapping of tags to custom rendering configurations.
+    ///
+    /// These names *must* be distinct from the renderer names, otherwise the keys will conflict
+    /// with the configs set for each renderer in this config section.
+    custom: HashMap<String, Renderers>,
+}
+
+impl Default for RenderConfig {
+    fn default() -> Self {
+        let default_renderer = Renderers::default();
+        RenderConfig {
+            default: default_renderer.to_string(),
+            unified: Unified::default(),
+            custom: HashMap::default(),
+        }
+    }
+}
+
+impl RenderConfig {
+    /// Verify that the custom user supplied keys don't conflict with built in types.
+    fn check_custom_render_keys(&self) -> anyhow::Result<()> {
+        let custom_map = &self.custom;
+        let render_iter = <Renderers as strum::IntoEnumIterator>::iter();
+        let conflicting_keys: Vec<String> = render_iter
+            .filter_map(|key| {
+                let key_str = key.to_string();
+                if custom_map.contains_key(&key_str) {
+                    Some(key_str)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let error_string = conflicting_keys.join(", ");
+        anyhow::ensure!(
+            conflicting_keys.is_empty(),
+            "Received invalid keys {}",
+            error_string
+        );
+        Ok(())
+    }
+
+    /// Get the renderer specified by the given tag.
+    ///
+    /// If the tag is not specified this will fall back to the default renderer. This is a
+    /// relatively expensive operation so it should be used once and the result should be saved.
+    pub fn get_renderer(self, tag: Option<String>) -> anyhow::Result<Renderers> {
+        self.check_custom_render_keys()?;
+        let final_tag = if let Some(t) = tag { t } else { self.default };
+        let mut render_map = self.custom;
+
+        // TODO(afnan): automate this with a proc macro so we don't have to
+        // manually sync each renderer engine by hand.
+        render_map.insert("unified".into(), Renderers::from(self.unified));
+
+        if let Some(renderer) = render_map.remove(&final_tag) {
+            Ok(renderer)
+        } else {
+            Err(anyhow::anyhow!(
+                "Specified tag {} not found in renderers",
+                final_tag
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_render_keys() {
+        let cfg = RenderConfig::default();
+        assert!(cfg.check_custom_render_keys().is_ok());
+    }
+
+    #[test]
+    fn test_custom_renderer_tags_collision() {
+        let custom_map: HashMap<String, Renderers> = HashMap::from([(
+            "unified".to_string(),
+            Renderers::Unified(Unified::default()),
+        )]);
+        let cfg = RenderConfig {
+            custom: custom_map,
+            ..Default::default()
+        };
+        assert!(cfg.check_custom_render_keys().is_err());
+    }
+}


### PR DESCRIPTION
Add a generic rendering interface for diffs. This defines a trait
implementation that the rest of the program can use instead of being
tied to a specific implementation.

To enable this we created a rendering trait, which serves as the
interface. We can trivially add new renderers by creating modules that
implement the `Renderer` trait and add them to the enum.

We also add the ability to define "rendering modes" in the config, which
is an arbitrary mapping of tags to a set of rendering settings. Users
can toggle different rendering modes through the command line and
specify the default one to use in the config file.
