### PR TITLE
chore: Derive eq

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -241,10 +241,10 @@ pub type RichHunk<'a> = DocumentType<Hunk<'a>>;
 /// The hunks that correspond to a document
 ///
 /// This type implements a helper builder function that can take
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Hunks<'a>(pub Vec<Hunk<'a>>);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RichHunks<'a>(pub Vec<RichHunk<'a>>);
 
 /// A builder struct for [`RichHunks`].

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -160,7 +160,7 @@ impl Default for DiffWriter {
 }
 
 /// User supplied parameters that are required to display a diff
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DisplayParameters<'a> {
     /// The hunks constituting the diff.
     pub hunks: RichHunks<'a>,


### PR DESCRIPTION
Addresses a clippy lint, derive `Eq` since these types derive `PartialEq`.
