### PR TITLE
style: Use single character patterns, `is_empty`

### DIFF
--- a/src/input_processing.rs
+++ b/src/input_processing.rs
@@ -294,11 +294,10 @@ fn build<'a>(vector: &RefCell<Vec<VectorLeaf<'a>>>, node: tree_sitter::Node<'a>,
             // puts newlines into their own nodes, which later causes errors when trying to print
             // these nodes. We just ignore those nodes.
             if node_text
-                .replace("\n", "")
+                .replace('\n', "")
                 .replace("\r\n", "")
-                .replace("\r", "")
-                .len()
-                == 0
+                .replace('\r', "")
+                .is_empty()
             {
                 return;
             }


### PR DESCRIPTION
* Use characters for single char patterns
* Use `is_empty` instead of comparing length to 0

These are suggestions from clippy.
