### PR TITLE
Add `aarch64-apple-darwin` CD target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,7 @@ jobs:
               target: x86_64-pc-windows-msvc,
               use-cross: false,
             }
+          - { os: macos-latest, target: aarch64-apple-darwin, use-cross: false }
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Enable testing against aarch64 on macOS. We will enable the CD pipeline
later as that will take a little more work.
