### PR TITLE
feat(rendering): Add JSON rendering mode

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,6 +5,7 @@ use crate::input_processing::{EditType, Entry};
 use crate::neg_idx_vec::NegIdxVec;
 use anyhow::Result;
 use logging_timer::time;
+use serde::Serialize;
 use std::fmt::Debug;
 use std::iter::FromIterator;
 use std::ops::Range;
@@ -67,7 +68,7 @@ fn common_suffix_len<T: PartialEq>(
 }
 
 /// The edit information representing a line
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Line<'a> {
     /// The index of the line in the original document
     pub line_index: usize,
@@ -87,7 +88,7 @@ impl<'a> Line<'a> {
 /// A grouping of consecutive edit lines for a document
 ///
 /// Every line in a hunk must be consecutive and in ascending order.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Hunk<'a>(pub Vec<Line<'a>>);
 
 /// Types of errors that come up when inserting an entry to a hunk
@@ -198,15 +199,15 @@ impl<'a> Hunk<'a> {
 ///
 /// A lot of items in the diff are delineated by whether they come from the old document or the new
 /// one. This enum generically defines an enum wrapper over those document types.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DocumentType<T: Debug + Clone + PartialEq> {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum DocumentType<T: Debug + Clone + PartialEq + Serialize> {
     Old(T),
     New(T),
 }
 
 impl<T> AsRef<T> for DocumentType<T>
 where
-    T: Debug + Clone + PartialEq,
+    T: Debug + Clone + PartialEq + Serialize,
 {
     fn as_ref(&self) -> &T {
         match self {
@@ -217,7 +218,7 @@ where
 
 impl<T> AsMut<T> for DocumentType<T>
 where
-    T: Debug + Clone + PartialEq,
+    T: Debug + Clone + PartialEq + Serialize,
 {
     fn as_mut(&mut self) -> &mut T {
         match self {
@@ -226,7 +227,7 @@ where
     }
 }
 
-impl<T: Debug + Clone + PartialEq> DocumentType<T> {
+impl<T: Debug + Clone + PartialEq + Serialize> DocumentType<T> {
     /// Move the inner object out and consume it.
     fn consume(self) -> T {
         match self {
@@ -244,7 +245,7 @@ pub type RichHunk<'a> = DocumentType<Hunk<'a>>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Hunks<'a>(pub Vec<Hunk<'a>>);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RichHunks<'a>(pub Vec<RichHunk<'a>>);
 
 /// A builder struct for [`RichHunks`].

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -1,0 +1,41 @@
+use std::io::Write;
+
+use crate::render::Renderer;
+use logging_timer::time;
+use serde::{Deserialize, Serialize};
+
+use super::DisplayData;
+
+/// A renderer that outputs json data about the diff.
+///
+/// This can be useful if you want to use `jq` or do some programatic analysis on the results.
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug, Default)]
+pub struct Json {
+    /// Whether to pretty print the output JSON.
+    pub pretty_print: bool,
+}
+
+impl Renderer for Json {
+    fn render(
+        &self,
+        writer: &mut super::TermWriter,
+        data: &super::DisplayData,
+    ) -> anyhow::Result<()> {
+        let json_str = self.generate_json_str(data)?;
+        write!(writer, "{}", &json_str)?;
+        Ok(())
+    }
+}
+
+impl Json {
+    /// Create a JSON string from the display data.
+    ///
+    /// This method handles display options that are set in the config.
+    #[time("trace")]
+    fn generate_json_str(&self, data: &DisplayData) -> Result<String, serde_json::Error> {
+        if self.pretty_print {
+            return serde_json::to_string_pretty(data);
+        }
+        serde_json::to_string(data)
+    }
+}


### PR DESCRIPTION
This implements a new JSON output mode for diffsitter. We have added
serialization support through the serde macros to the structs passed to
the render interface to make it easier to convert data to JSON.

This is a first pass and we will likely end up adding more information
to the JSON output.
