### PR TITLE
Allow dynamic-grammar-libs to be found on NetBSD

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -139,7 +139,7 @@ fn fn_name_from_lang(lang: &str) -> String {
 fn lib_name_from_lang(lang: &str) -> String {
     let extension = if cfg!(target_os = "macos") {
         "dylib"
-    } else if cfg!(target_os = "linux") {
+    } else if cfg!(any(target_os = "linux", target_os = "netbsd")) {
         "so"
     } else if cfg!(target_os = "windows") {
         "dll"


### PR DESCRIPTION
Update the code so diffsitter uses the correct extension for shared library objects on netbsd.