### PR TITLE
feat(processing): Filter by TS node type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "diffsitter"
 version = "0.7.3"
 dependencies = [
@@ -361,6 +367,7 @@ dependencies = [
  "libloading",
  "log",
  "logging_timer",
+ "mockall",
  "phf",
  "pretty_assertions",
  "pretty_env_logger",
@@ -428,6 +435,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -508,6 +521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +537,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs_extra"
@@ -684,6 +712,15 @@ name = "is_debug"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -864,6 +901,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1106,36 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -1359,6 +1459,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "test-case"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ enum-iterator = "1.2.0"
 [dev-dependencies]
 test-case = "2.2.2"
 pretty_assertions = "1.3.0"
+mockall = "0.11.3"
 
 # We need the backtrace feature to enable snapshot name generation in
 # single-threaded tests (tests using cargo cross run single-threaded due to

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ test_data/short/rust/a.rs -> test_data/short/rust/b.rs
 
 *Note: the numbers correspond to line numbers from the original files.*
 
+You can also filter which tree sitter nodes are considered in the diff through 
+the config file.
+
 Since it uses the AST to calculate the difference, it knows that the formatting
 differences in `main` between the two files isn't a meaningful difference, so
 it doesn't show up in the diff.
@@ -146,6 +149,25 @@ it doesn't show up in the diff.
 It also has extensive logging if you want to debug or see timing information:
 
 ![screenshot of rust diff with logs](assets/rust_example_logs.png)
+
+### Node filtering
+
+You can filter the nodes that are considered in the diff by setting 
+`include_nodes` or `exclude_nodes` in the config file. `exclude_nodes` always 
+takes precedence over `include_nodes`, and the type of a node is the `kind`
+of a tree-sitter node.
+
+This feature currently only applies to leaf nodes, but we could exclude nodes
+recursively if there's demand for it.
+
+```json5
+"input-processing": {
+    // You can exclude different tree sitter node types - this rule takes precedence over `include_kinds`.
+    "exclude_kinds": ["string"],
+    // You can specifically allow only certain tree sitter node types
+    "include_kinds": ["method_definition"],
+}
+```
 
 ## Installation
 

--- a/assets/sample_config.json5
+++ b/assets/sample_config.json5
@@ -102,5 +102,9 @@
     "fallback-cmd": "diff",
     "input-processing": {
         "split-graphemes": true,
+        // You can exclude different tree sitter node types - this rule takes precedence over `include_kinds`.
+        "exclude_kinds": ["string"],
+        // You can specifically allow only certain tree sitter node types
+        "include_kinds": ["method_definition"],
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,10 @@ mod tests {
         let ast_data_a = generate_ast_vector_data(path_a, None, &config).unwrap();
         let ast_data_b = generate_ast_vector_data(path_b, None, &config).unwrap();
 
-        let processor = input_processing::TreeSitterProcessor { split_graphemes };
+        let processor = input_processing::TreeSitterProcessor {
+            split_graphemes,
+            ..Default::default()
+        };
 
         let diff_vec_a = processor.process(&ast_data_a.tree, &ast_data_a.text);
         let diff_vec_b = processor.process(&ast_data_b.tree, &ast_data_b.text);


### PR DESCRIPTION
Allow users to explicitly include or exclude tree sitter nodes using the
tree sitter node types. This adds a config option that allows users to set
the node types they want to include/exclude.

We have updated the README and the sample config with information about the new
feature. We have also added tests to ensure that the filtering logic works as
expected.

This addresses #349.