### PR TITLE
refactor: Use Write trait, separate term info

### DIFF
--- a/src/bin/diffsitter.rs
+++ b/src/bin/diffsitter.rs
@@ -16,7 +16,7 @@ use libdiffsitter::render::{DisplayData, DocumentDiffData, Renderer};
 use log::{debug, error, info, warn, LevelFilter};
 use serde_json as json;
 use std::{
-    io::{self, BufWriter, Write},
+    io,
     path::Path,
     process::{Child, Command},
 };
@@ -149,8 +149,9 @@ fn run_diff(args: Args, config: Config) -> Result<()> {
     // the user just cares about the output at the end, we don't care about how frequently the
     // terminal does partial updates or anything like that. If the user is curious about progress,
     // they can enable logging and see when hunks are processed and written to the buffer.
-    let mut buf_writer = BufWriter::new(Term::stdout());
-    renderer.render(&mut buf_writer, &params)?;
+    let mut buf_writer = Term::buffered_stdout();
+    let term_info = buf_writer.clone();
+    renderer.render(&mut buf_writer, &params, Some(&term_info))?;
     buf_writer.flush()?;
     Ok(())
 }

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -1,10 +1,9 @@
-use std::io::Write;
-
+use super::DisplayData;
 use crate::render::Renderer;
+use console::Term;
 use logging_timer::time;
 use serde::{Deserialize, Serialize};
-
-use super::DisplayData;
+use std::io::Write;
 
 /// A renderer that outputs json data about the diff.
 ///
@@ -18,8 +17,9 @@ pub struct Json {
 impl Renderer for Json {
     fn render(
         &self,
-        writer: &mut super::TermWriter,
+        writer: &mut dyn Write,
         data: &super::DisplayData,
+        _term_info: Option<&Term>,
     ) -> anyhow::Result<()> {
         let json_str = self.generate_json_str(data)?;
         write!(writer, "{}", &json_str)?;


### PR DESCRIPTION
Pass a generic write trait to the render trait so we can seamlessly swap
out different sinks to write out to. We also pass in the term object
separately as an optional reference so renderers can dynamically react
to the terminal/presence of a TTY.
