### PR TITLE
ci: Update checkout action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,9 +43,9 @@ jobs:
               use-cross: false,
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          submodules: true
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Update the checkout action to v3 and don't recursively initialize
submodules. This fixes an error in another PR where recursively checking out submodules was causing an error.
