### PR TITLE
fix: Use checkout v3 in CD pipeline

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -138,9 +138,9 @@ jobs:
             use-cross: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          submodules: true
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Update the checkout action to use v3 and non-recursively update
submodules, which should fix the breaking nightly CD job.
