### PR TITLE
fix: Use a newer cargo deb version

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
-          cargo install cargo-deb --version 1.29.2
+          cargo install cargo-deb --version 1.42.2
           cargo deb
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
 


### PR DESCRIPTION
Bump the version of cargo deb to the latest one. The CD workflow has
been failing because Cargo is unable to resolve `cargo-deb` because of a
library requirement. Hopefully updating to a newer version will fix the
issue.
