### PR TITLE
refactor: Split up libraries and binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,18 @@ include = [
   "!assets/*",
 ]
 
+[[bin]]
+name = "diffsitter"
+path = "src/bin/diffsitter.rs"
+
+[[bin]]
+name = "diffsitter_completions"
+path = "src/bin/diffsitter_completions.rs"
+
+[lib]
+name = "libdiffsitter"
+path = "src/lib.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/bin/diffsitter.rs
+++ b/src/bin/diffsitter.rs
@@ -1,0 +1,252 @@
+use ::console::Term;
+use anyhow::Result;
+use clap::CommandFactory;
+use clap::FromArgMatches;
+use human_panic::setup_panic;
+use libdiffsitter::cli;
+use libdiffsitter::cli::Args;
+use libdiffsitter::config::{Config, ReadError};
+use libdiffsitter::console_utils;
+use libdiffsitter::diff;
+use libdiffsitter::generate_ast_vector_data;
+#[cfg(feature = "static-grammar-libs")]
+use libdiffsitter::parse::supported_languages;
+use libdiffsitter::parse::{generate_language, language_from_ext};
+use libdiffsitter::render::{DisplayData, DocumentDiffData, Renderer};
+use log::{debug, error, info, warn, LevelFilter};
+use serde_json as json;
+use std::{
+    io::{self, BufWriter, Write},
+    path::Path,
+    process::{Child, Command},
+};
+
+#[cfg(feature = "better-build-info")]
+use shadow_rs::shadow;
+
+#[cfg(feature = "jemallocator")]
+use jemallocator::Jemalloc;
+
+#[cfg(feature = "jemallocator")]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+/// Return an instance of [Config] from a config file path (or the inferred default path)
+///
+/// If a config path isn't provided or there is some other failure, fall back to the default
+/// config. This will error out if a config is found but is found to be an invalid config.
+fn derive_config(args: &Args) -> Result<Config> {
+    if args.no_config {
+        info!("`no_config` specified, falling back to default config");
+        return Ok(Config::default());
+    }
+    match Config::try_from_file(args.config.as_ref()) {
+        // If the config was parsed correctly with no issue, we don't have to do anything
+        Ok(config) => Ok(config),
+        // If there was an error, we need to figure out whether to propagate the error or fall
+        // back to the default config
+        Err(e) => match e {
+            // If it is a recoverable error, ex: not being able to find the default file path or
+            // not finding a file at all isn't a hard error, it makes sense for us to use the
+            // default config.
+            ReadError::ReadFileFailure(_) | ReadError::NoDefault => {
+                warn!("{} - falling back to default config", e);
+                Ok(Config::default())
+            }
+            // If we *do* find a config file and it doesn't parse correctly, we should return an
+            // error and let the user know that their config is incorrect. This isn't a browser,
+            // we can't just silently march forward and hope for the best.
+            ReadError::DeserializationFailure(e) => {
+                error!("Failed to deserialize config file: {}", e);
+                Err(anyhow::anyhow!(e))
+            }
+        },
+    }
+}
+
+/// Check if the input files are supported by this program.
+///
+/// If the user provides a language override, this will check that the language is supported by the
+/// program. If the user supplies any extension mappings, this will check to see if the extension
+/// is in the mapping or if it's one of the user-defined ones.
+///
+/// This is used to determine whether the program should fall back to another diff utility.
+fn are_input_files_supported(args: &Args, config: &Config) -> bool {
+    let paths = [&args.old, &args.new];
+
+    // If there's a user override at the command line, that takes priority over everything else.
+    if let Some(file_type) = &args.file_type {
+        return generate_language(file_type, &config.grammar).is_ok();
+    }
+
+    // For each path, attempt to create a parser for that given extension, checking for any
+    // possible overrides.
+    for path in paths.into_iter().flatten() {
+        debug!("Checking if {} can be parsed", path.display());
+        let ext = path.extension();
+
+        if ext.is_none() {
+            return false;
+        }
+
+        let ext = ext.unwrap();
+
+        if ext.to_str().is_none() {
+            warn!("No filetype deduced for {}", path.display());
+            return false;
+        }
+
+        let ext = ext.to_str().unwrap();
+
+        if language_from_ext(ext, &config.grammar).is_err() {
+            error!("Extension {} not supported", ext);
+            return false;
+        }
+    }
+    debug!("Extensions for both input files are supported");
+    true
+}
+
+/// Take the diff of two files
+fn run_diff(args: Args, config: Config) -> Result<()> {
+    // Check whether we can get the renderer up front. This is more ergonomic than running the diff
+    // and then informing the user their renderer choice is incorrect/that the config is invalid.
+    let render_config = config.formatting;
+    let render_param = args.renderer;
+    let renderer = render_config.get_renderer(render_param)?;
+
+    let file_type = args.file_type.as_deref();
+    let path_a = args.old.as_ref().unwrap();
+    let path_b = args.new.as_ref().unwrap();
+
+    // This looks a bit weird because the ast vectors and some other data reference data in the
+    // AstVectorData structs. Because of that, we can't make a function that generates the ast
+    // vectors in one shot.
+
+    let ast_data_a = generate_ast_vector_data(path_a.clone(), file_type, &config.grammar)?;
+    let ast_data_b = generate_ast_vector_data(path_b.clone(), file_type, &config.grammar)?;
+    let diff_vec_a = config
+        .input_processing
+        .process(&ast_data_a.tree, &ast_data_a.text);
+    let diff_vec_b = config
+        .input_processing
+        .process(&ast_data_b.tree, &ast_data_b.text);
+
+    let hunks = diff::compute_edit_script(&diff_vec_a, &diff_vec_b)?;
+    let params = DisplayData {
+        hunks,
+        old: DocumentDiffData {
+            filename: &ast_data_a.path.to_string_lossy(),
+            text: &ast_data_a.text,
+        },
+        new: DocumentDiffData {
+            filename: &ast_data_b.path.to_string_lossy(),
+            text: &ast_data_b.text,
+        },
+    };
+    // Use a buffered terminal instead of a normal unbuffered terminal so we can amortize the cost
+    // of printing. It doesn't really matter how frequently the terminal prints to stdout because
+    // the user just cares about the output at the end, we don't care about how frequently the
+    // terminal does partial updates or anything like that. If the user is curious about progress,
+    // they can enable logging and see when hunks are processed and written to the buffer.
+    let mut buf_writer = BufWriter::new(Term::stdout());
+    renderer.render(&mut buf_writer, &params)?;
+    buf_writer.flush()?;
+    Ok(())
+}
+
+/// Serialize the default options struct to a json file and print that to stdout
+fn dump_default_config() -> Result<()> {
+    let config = Config::default();
+    println!("{}", json::to_string_pretty(&config)?);
+    Ok(())
+}
+
+/// Run the diff fallback command using the command and the given paths.
+fn diff_fallback(cmd: &str, old: &Path, new: &Path) -> io::Result<Child> {
+    debug!("Spawning diff fallback process");
+    Command::new(cmd).args([old, new]).spawn()
+}
+
+/// Print a list of the languages that this instance of diffsitter was compiled with
+pub fn list_supported_languages() {
+    #[cfg(feature = "static-grammar-libs")]
+    {
+        let languages = supported_languages();
+        println!("This program was compiled with support for:");
+
+        for language in languages {
+            println!("- {language}");
+        }
+    }
+
+    #[cfg(feature = "dynamic-grammar-libs")]
+    {
+        println!("This program will dynamically load grammars from shared libraries");
+    }
+}
+
+/// Print shell completion scripts to `stdout`.
+///
+/// This is a basic wrapper for the subcommand.
+fn print_shell_completion(shell: clap_complete::Shell) {
+    let mut app = cli::Args::command();
+    clap_complete::generate(shell, &mut app, "diffsitter", &mut io::stdout());
+}
+
+fn main() -> Result<()> {
+    // Set up a panic handler that will yield more human-readable errors.
+    setup_panic!();
+
+    #[cfg(feature = "better-build-info")]
+    shadow!(build);
+
+    use cli::Command;
+
+    #[cfg(feature = "better-build-info")]
+    let command = Args::command().version(build::CLAP_LONG_VERSION);
+
+    #[cfg(not(feature = "better-build-info"))]
+    let command = Args::command();
+    let matches = command.get_matches();
+    let args = Args::from_arg_matches(&matches)?;
+
+    // We parse the config as early as possible so users can get quick feedback if anything is off
+    // with their config.
+    let config = derive_config(&args)?;
+
+    // Users can supply a command that will *not* run a diff, which we handle here
+    if let Some(cmd) = args.cmd {
+        match cmd {
+            Command::List => list_supported_languages(),
+            Command::DumpDefaultConfig => dump_default_config()?,
+            Command::GenCompletion { shell } => {
+                print_shell_completion(shell.into());
+            }
+        }
+    } else {
+        let log_level = if args.debug {
+            LevelFilter::Trace
+        } else {
+            LevelFilter::Off
+        };
+        pretty_env_logger::formatted_timed_builder()
+            .filter_level(log_level)
+            .init();
+        console_utils::set_term_colors(args.color_output);
+        // First check if the input files can be parsed with tree-sitter.
+        let files_supported = are_input_files_supported(&args, &config);
+
+        // If the files are supported by our grammars, awesome. Otherwise fall back to a diff
+        // utility if one is specified.
+        if files_supported {
+            run_diff(args, config)?;
+        } else if let Some(cmd) = config.fallback_cmd {
+            info!("Input files are not supported but user has configured diff fallback");
+            diff_fallback(&cmd, &args.old.unwrap(), &args.new.unwrap())?;
+        } else {
+            anyhow::bail!("Unsupported file type with no fallback command specified.");
+        }
+    }
+    Ok(())
+}

--- a/src/bin/diffsitter_completions.rs
+++ b/src/bin/diffsitter_completions.rs
@@ -1,0 +1,11 @@
+use clap::Parser;
+
+/// A program that generates completions for the `diffsitter` program.
+///
+/// This can generate completions for different shells, manpages, etc.
+#[derive(Debug, Parser)]
+struct Args {}
+
+fn main() {
+    eprintln!("This functionality has not yet been implemented.")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,56 @@
+//! The supporting library for `diffsitter`.
+//!
+//! This library is not particularly cohesive or well organized. It exists to support the
+//! diffsitter binary and I am open to refactoring it and organizing it better if there's demand.
+//!
+//! In the meantime, buyer beware.
+//!
+//! All of the methods used to create diffsitter are here and we have attempted to keep the library
+//! at least somewhat sane and organized for our own usage.
+
+pub mod cli;
+pub mod config;
+pub mod console_utils;
+pub mod diff;
+pub mod input_processing;
+pub mod neg_idx_vec;
+pub mod parse;
+pub mod render;
+
+use anyhow::Result;
+use input_processing::VectorData;
+use log::{debug, info};
+use parse::GrammarConfig;
+use std::{fs, path::PathBuf};
+
+/// Create an AST vector from a path
+///
+/// This returns an `AstVector` and a pinned struct with the owned data, which the `AstVector`
+/// references.
+///
+/// `data` is used as an out-parameter. We need some external struct we can reference because the
+/// return type references the data in that struct.
+///
+/// This returns an anyhow [Result], which is bad practice for a library and will need to be
+/// refactored in the future. This method was originally used in the `diffsitter` binary so we
+/// didn't feel the need to specify a specific error type.
+pub fn generate_ast_vector_data(
+    path: PathBuf,
+    file_type: Option<&str>,
+    grammar_config: &GrammarConfig,
+) -> Result<VectorData> {
+    let text = fs::read_to_string(&path)?;
+    let file_name = path.to_string_lossy();
+    debug!("Reading {} to string", file_name);
+
+    if let Some(file_type) = file_type {
+        info!(
+            "Using user-set filetype \"{}\" for {}",
+            file_type, file_name
+        );
+    } else {
+        info!("Will deduce filetype from file extension");
+    };
+    let tree = parse::parse_file(&path, file_type, grammar_config)?;
+    Ok(VectorData { text, tree, path })
+}

--- a/src/neg_idx_vec.rs
+++ b/src/neg_idx_vec.rs
@@ -6,10 +6,11 @@ use std::ops::{Index, IndexMut};
 
 /// A vector that can be indexed with a negative index, like with Python.
 ///
-/// ```
+/// ```rust
+/// use libdiffsitter::neg_idx_vec::NegIdxVec;
 /// let v = NegIdxVec::from(vec![1, 2, 3]);
 /// let last_negative = v[-1];
-/// let last = v[v.0.len() - 1];
+/// let last = v[(v.len() - 1).try_into().unwrap()];
 /// ```
 ///
 /// A negative index corresponds to an offset from the end of the vector.
@@ -30,8 +31,9 @@ impl<T> NegIdxVec<T> {
     /// This will create an internal vector and all offsets will be pegged relative to the size of
     /// this vector.
     ///
-    /// ```
-    /// let v = NegIdxVec::new(1, Default::default);
+    /// ```rust
+    /// use libdiffsitter::neg_idx_vec::NegIdxVec;
+    /// let v: NegIdxVec<usize> = NegIdxVec::new(1, Default::default);
     /// ```
     pub fn new<F>(len: usize, f: F) -> Self
     where

--- a/tests/regression_test.rs
+++ b/tests/regression_test.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+    use libdiffsitter::{
+        diff::compute_edit_script, generate_ast_vector_data, input_processing::TreeSitterProcessor,
+        parse::GrammarConfig,
+    };
+    use std::path::PathBuf;
+    use test_case::test_case;
+
+    /// Get paths to input files for tests
+    fn get_test_paths(test_type: &str, test_name: &str, ext: &str) -> (PathBuf, PathBuf) {
+        let test_data_root = PathBuf::from(format!("./test_data/{test_type}/{test_name}"));
+        let path_a = test_data_root.join(format!("a.{ext}"));
+        let path_b = test_data_root.join(format!("b.{ext}"));
+        assert!(
+            path_a.exists(),
+            "test data path {} does not exist",
+            path_a.to_str().unwrap()
+        );
+        assert!(
+            path_b.exists(),
+            "test data path {} does not exist",
+            path_b.to_str().unwrap()
+        );
+
+        (path_a, path_b)
+    }
+
+    #[test_case("short", "rust", "rs", true)]
+    #[test_case("short", "python", "py", true)]
+    #[test_case("short", "go", "go", true)]
+    #[test_case("medium", "rust", "rs", true)]
+    #[test_case("medium", "rust", "rs", false)]
+    #[test_case("medium", "cpp", "cpp", true)]
+    #[test_case("medium", "cpp", "cpp", false)]
+    fn diff_hunks_snapshot(test_type: &str, name: &str, ext: &str, split_graphemes: bool) {
+        let (path_a, path_b) = get_test_paths(test_type, name, ext);
+        let config = GrammarConfig::default();
+        let ast_data_a = generate_ast_vector_data(path_a, None, &config).unwrap();
+        let ast_data_b = generate_ast_vector_data(path_b, None, &config).unwrap();
+
+        let processor = TreeSitterProcessor {
+            split_graphemes,
+            ..Default::default()
+        };
+
+        let diff_vec_a = processor.process(&ast_data_a.tree, &ast_data_a.text);
+        let diff_vec_b = processor.process(&ast_data_b.tree, &ast_data_b.text);
+        let diff_hunks = compute_edit_script(&diff_vec_a, &diff_vec_b).unwrap();
+
+        // We have to set the snapshot name manually, otherwise there appear to be threading issues
+        // and we end up with more snapshot files than there are tests, which cause
+        // nondeterministic errors.
+        let snapshot_name = format!("{test_type}_{name}_{split_graphemes}");
+        assert_debug_snapshot!(snapshot_name, diff_hunks);
+    }
+}

--- a/tests/snapshots/regression_test__tests__medium_cpp_false.snap
+++ b/tests/snapshots/regression_test__tests__medium_cpp_false.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: tests/regression_test.rs
 expression: diff_hunks
 ---
 RichHunks(
@@ -19,7 +19,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 12,
-                                    column: 13,
+                                    column: 12,
                                 },
                                 kind_id: 1,
                             },
@@ -32,7 +32,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 12,
-                                    column: 25,
+                                    column: 24,
                                 },
                                 kind_id: 1,
                             },
@@ -45,7 +45,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 12,
-                                    column: 37,
+                                    column: 36,
                                 },
                                 kind_id: 1,
                             },
@@ -69,7 +69,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 17,
-                                    column: 13,
+                                    column: 12,
                                 },
                                 kind_id: 1,
                             },
@@ -82,7 +82,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 17,
-                                    column: 25,
+                                    column: 24,
                                 },
                                 kind_id: 1,
                             },
@@ -95,7 +95,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 17,
-                                    column: 37,
+                                    column: 36,
                                 },
                                 kind_id: 1,
                             },
@@ -112,66 +112,27 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "s",
+                                text: "std",
                                 start_position: Point {
                                     row: 43,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 43,
-                                    column: 5,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 6,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 7,
+                                    column: 4,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (43, 7) - (43, 9)},
-                                text: ":",
+                                text: "::",
                                 start_position: Point {
                                     row: 43,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 43,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (43, 7) - (43, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 9,
+                                    column: 7,
                                 },
                                 kind_id: 43,
                             },
@@ -182,66 +143,27 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "s",
+                                text: "std",
                                 start_position: Point {
                                     row: 44,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 44,
-                                    column: 5,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 6,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 7,
+                                    column: 4,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (44, 7) - (44, 9)},
-                                text: ":",
+                                text: "::",
                                 start_position: Point {
                                     row: 44,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 44,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (44, 7) - (44, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 9,
+                                    column: 7,
                                 },
                                 kind_id: 43,
                             },
@@ -252,66 +174,27 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "s",
+                                text: "std",
                                 start_position: Point {
                                     row: 45,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 45,
-                                    column: 5,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 6,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 7,
+                                    column: 4,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (45, 7) - (45, 9)},
-                                text: ":",
+                                text: "::",
                                 start_position: Point {
                                     row: 45,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 45,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (45, 7) - (45, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 9,
+                                    column: 7,
                                 },
                                 kind_id: 43,
                             },
@@ -322,66 +205,27 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "s",
+                                text: "std",
                                 start_position: Point {
                                     row: 46,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 46,
-                                    column: 5,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 6,
-                                },
-                                kind_id: 440,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 7,
+                                    column: 4,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (46, 7) - (46, 9)},
-                                text: ":",
+                                text: "::",
                                 start_position: Point {
                                     row: 46,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 46,
-                                    column: 8,
-                                },
-                                kind_id: 43,
-                            },
-                            Entry {
-                                reference: {Node :: (46, 7) - (46, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 9,
+                                    column: 7,
                                 },
                                 kind_id: 43,
                             },

--- a/tests/snapshots/regression_test__tests__medium_cpp_true.snap
+++ b/tests/snapshots/regression_test__tests__medium_cpp_true.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: tests/regression_test.rs
 expression: diff_hunks
 ---
 RichHunks(
@@ -19,7 +19,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 12,
-                                    column: 12,
+                                    column: 13,
                                 },
                                 kind_id: 1,
                             },
@@ -32,7 +32,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 12,
-                                    column: 24,
+                                    column: 25,
                                 },
                                 kind_id: 1,
                             },
@@ -45,7 +45,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 12,
-                                    column: 36,
+                                    column: 37,
                                 },
                                 kind_id: 1,
                             },
@@ -69,7 +69,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 17,
-                                    column: 12,
+                                    column: 13,
                                 },
                                 kind_id: 1,
                             },
@@ -82,7 +82,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 17,
-                                    column: 24,
+                                    column: 25,
                                 },
                                 kind_id: 1,
                             },
@@ -95,7 +95,7 @@ RichHunks(
                                 },
                                 end_position: Point {
                                     row: 17,
-                                    column: 36,
+                                    column: 37,
                                 },
                                 kind_id: 1,
                             },
@@ -112,27 +112,66 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "std",
+                                text: "s",
                                 start_position: Point {
                                     row: 43,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 43,
-                                    column: 4,
+                                    column: 5,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 6,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 7,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (43, 7) - (43, 9)},
-                                text: "::",
+                                text: ":",
                                 start_position: Point {
                                     row: 43,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 43,
-                                    column: 7,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (43, 7) - (43, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 43,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 43,
+                                    column: 9,
                                 },
                                 kind_id: 43,
                             },
@@ -143,27 +182,66 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "std",
+                                text: "s",
                                 start_position: Point {
                                     row: 44,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 44,
-                                    column: 4,
+                                    column: 5,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 6,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 7,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (44, 7) - (44, 9)},
-                                text: "::",
+                                text: ":",
                                 start_position: Point {
                                     row: 44,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 44,
-                                    column: 7,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (44, 7) - (44, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 44,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 44,
+                                    column: 9,
                                 },
                                 kind_id: 43,
                             },
@@ -174,27 +252,66 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "std",
+                                text: "s",
                                 start_position: Point {
                                     row: 45,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 45,
-                                    column: 4,
+                                    column: 5,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 6,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 7,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (45, 7) - (45, 9)},
-                                text: "::",
+                                text: ":",
                                 start_position: Point {
                                     row: 45,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 45,
-                                    column: 7,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (45, 7) - (45, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 45,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 45,
+                                    column: 9,
                                 },
                                 kind_id: 43,
                             },
@@ -205,27 +322,66 @@ RichHunks(
                         entries: [
                             Entry {
                                 reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "std",
+                                text: "s",
                                 start_position: Point {
                                     row: 46,
                                     column: 4,
                                 },
                                 end_position: Point {
                                     row: 46,
-                                    column: 4,
+                                    column: 5,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "t",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 5,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 6,
+                                },
+                                kind_id: 440,
+                            },
+                            Entry {
+                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
+                                text: "d",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 6,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 7,
                                 },
                                 kind_id: 440,
                             },
                             Entry {
                                 reference: {Node :: (46, 7) - (46, 9)},
-                                text: "::",
+                                text: ":",
                                 start_position: Point {
                                     row: 46,
                                     column: 7,
                                 },
                                 end_position: Point {
                                     row: 46,
-                                    column: 7,
+                                    column: 8,
+                                },
+                                kind_id: 43,
+                            },
+                            Entry {
+                                reference: {Node :: (46, 7) - (46, 9)},
+                                text: ":",
+                                start_position: Point {
+                                    row: 46,
+                                    column: 8,
+                                },
+                                end_position: Point {
+                                    row: 46,
+                                    column: 9,
                                 },
                                 kind_id: 43,
                             },

--- a/tests/snapshots/regression_test__tests__medium_rust_false.snap
+++ b/tests/snapshots/regression_test__tests__medium_rust_false.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: tests/regression_test.rs
 expression: diff_hunks
 ---
 RichHunks(

--- a/tests/snapshots/regression_test__tests__medium_rust_true.snap
+++ b/tests/snapshots/regression_test__tests__medium_rust_true.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: tests/regression_test.rs
 expression: diff_hunks
 ---
 RichHunks(

--- a/tests/snapshots/regression_test__tests__short_go_true.snap
+++ b/tests/snapshots/regression_test__tests__short_go_true.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: tests/regression_test.rs
 expression: diff_hunks
 ---
 RichHunks(

--- a/tests/snapshots/regression_test__tests__short_python_true.snap
+++ b/tests/snapshots/regression_test__tests__short_python_true.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: tests/regression_test.rs
 expression: diff_hunks
 ---
 RichHunks(

--- a/tests/snapshots/regression_test__tests__short_rust_true.snap
+++ b/tests/snapshots/regression_test__tests__short_rust_true.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: tests/regression_test.rs
 expression: diff_hunks
 ---
 RichHunks(


### PR DESCRIPTION
Refactor the code into a split between the main diffsitter library and
other binaries.

This makes the code cleaner, allows us to refactor further if we want to
use procedural macros, and allows us to add benchmark harnesses (which
is not possible with a binary-only crate).

There is more refactoring to be done, but we are trying to keep PRs as
minimal as possible for the ease of review and good `git` hygiene.

Changes consisted of making items public so the binaries can access
required library methods, updating imports, some doctest examples
(due to visibility changes), and moving snapshot files to a new location
for regression tests. I thought it made more sense for the regression tests
to be in the standard location for integration tests for a rust library rather
than being randomly in the `main.rs` file.