### PR TITLE
ci: Use latest rust-cache action

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -158,7 +158,7 @@ jobs:
           command: build
           use-cross: ${{ matrix.job.use-cross }}
           args: --profile production --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.job.target }}-release
       - name: Install packages (Windows)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
           target: ${{ matrix.job.target }}
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.job.target }}
       - name: Check formatting


### PR DESCRIPTION
Update the version of the rust cache action used in the Github actions
job. We have seen warnings about outdated APIs being used that should
be addressed by this version bump.
