### PR TITLE
build: Add `default-run` manifest key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ include = [
   "!**/target/**/*",
   "!assets/*",
 ]
+default-run = "diffsitter"
 
 [[bin]]
 name = "diffsitter"


### PR DESCRIPTION
This instructs `cargo run` to run the `diffsitter` binary for default,
which is what we usually want.
