### PR TITLE
ci: Use different paths for rust cross

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -199,13 +199,23 @@ jobs:
           cp .\bin\git-diffsitter .\git-diffsitter
           zip -r diffsitter-${{ matrix.job.target }}.zip ${{ matrix.job.artifact_name }} git-diffsitter
 
-      - name: Archive release assets
-        if: matrix.job.os != 'windows-latest'
+      - name: Archive release assets (cargo cross)
+        if: matrix.job.os != 'windows-latest' && matrix.job.use-cross
         id: archive_release_assets_unix_like
         shell: bash
         run: |
           mkdir -p diffsitter-${{ matrix.job.target }}
           cp target/${{ matrix.job.target }}/production/${{ matrix.job.artifact_name }} diffsitter-${{ matrix.job.target }}
+          cp bin/git-diffsitter diffsitter-${{ matrix.job.target }}
+          tar -czvf diffsitter-${{ matrix.job.target }}.tar.gz diffsitter-${{ matrix.job.target }}
+
+      - name: Archive release assets (without cross)
+        if: matrix.job.os != 'windows-latest' && matrix.job.use-cross == false
+        id: archive_release_assets_unix_like
+        shell: bash
+        run: |
+          mkdir -p diffsitter-${{ matrix.job.target }}
+          cp target/production/${{ matrix.job.artifact_name }} diffsitter-${{ matrix.job.target }}
           cp bin/git-diffsitter diffsitter-${{ matrix.job.target }}
           tar -czvf diffsitter-${{ matrix.job.target }}.tar.gz diffsitter-${{ matrix.job.target }}
 


### PR DESCRIPTION
Use the standard output path when we aren't using rust cross. I'm not
sure why this worked before and stopped working all of a sudden. I think
cross outputs to a directory specific to the target triple.
