### PR TITLE
ci: Set target directory to consistent location

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           command: build
           use-cross: ${{ matrix.job.use-cross }}
-          args: --profile production --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs
+          args: --profile production --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs --target-dir ./target/${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.job.target }}-release


### PR DESCRIPTION
For some reason it seems like the target directory for Cargo has changed
which is causing an error in the CD pipeline. We now manually set the
target directory to the expected location so the step that copies out
release assets won't fail.
