### PR TITLE
ci: Update Github actions to use more recent APIs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -292,6 +292,9 @@ jobs:
 
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
+      - uses: taiki-e/install-action@cargo-deb
+        with:
+          tool: cargo-deb@1.42.2
         run: |
           cargo install cargo-deb --version 1.42.2
           cargo deb

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -150,6 +150,9 @@ jobs:
         with:
           submodules: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: cd-${{steps.toolchain.outputs.name}}
       - if: ${{ matrix.job.os == 'ubuntu-latest' }}
         name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1
@@ -167,9 +170,6 @@ jobs:
         env:
           MACOS_DEPLOYMENT_TARGET: 10.7
         run: cargo build --profile production --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: cd-${{steps.toolchain.outputs.name}}
       - name: Install packages (Windows)
         if: matrix.job.os == 'windows-latest'
         uses: crazy-max/ghaction-chocolatey@v1.4.0

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -247,6 +247,7 @@ jobs:
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
+          cargo build --profile production
           cargo deb --profile production
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -250,9 +250,7 @@ jobs:
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
-          cargo build --profile production
-          cargo deb --profile production
-          cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
+          cargo build --profile production && cargo deb --profile production && cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
         env:
           CARGO_TARGET_DIR: "./target"
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -228,16 +228,25 @@ jobs:
           echo "CHECKSUM=$checksum"
           echo "CHECKSUM=$checksum" >> $GITHUB_ENV
 
-      - name: Upload binary to release
-        if: matrix.job.os != 'windows-latest'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          asset_path: diffsitter-${{ matrix.job.target }}.tar.gz
-          asset_name: diffsitter-${{ matrix.job.target }}.tar.gz
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_content_type: application/octet-stream
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
+          # Note that glob pattern is not supported yet.
+          bin: diffsitter
+          # (optional) Archive name (non-extension portion of filename) to be uploaded.
+          # [default value: $bin-$target]
+          # [possible values: the following variables and any string]
+          #   variables:
+          #     - $bin    - Binary name (non-extension portion of filename).
+          #     - $target - Target triple.
+          #     - $tag    - Tag of this release.
+          # When multiple binary names are specified, default archive name or $bin variable cannot be used.
+          archive: $bin-$target
+          # (required) GitHub token for uploading assets to GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tar: unix
+          zip: windows
+          target: ${{ matrix.job.target }}
 
       - name: Upload binary to release (Windows)
         if: matrix.job.os == 'windows-latest'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -251,7 +251,7 @@ jobs:
           cargo deb --profile production
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
         env:
-          CARGO_TARGET_DIR=./target
+          CARGO_TARGET_DIR: "./target"
 
       - name: Upload Debian file (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -88,9 +88,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install GH CLI
-        uses: dev-hanz-ops/install-gh-cli-action
-
       - name: Create artifacts directory
         run: mkdir artifacts
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -142,25 +142,17 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.job.target }}
-          profile: minimal
-          override: true
-
+      - uses: dtolnay/rust-toolchain@stable
+        targets: ${{ matrix.job.target }}
+      - uses: taiki-e/install-action@nextest
       - name: Build optimized binary
         env:
           MACOS_DEPLOYMENT_TARGET: 10.7
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          use-cross: ${{ matrix.job.use-cross }}
-          args: --profile production --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs
+        run: cargo build --profile production --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.job.target }}-release
+          key: cd-${{steps.toolchain.outputs.name}}
+
       - name: Install packages (Windows)
         if: matrix.job.os == 'windows-latest'
         uses: crazy-max/ghaction-chocolatey@v1.4.0

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -249,7 +249,10 @@ jobs:
         run: |
           cargo build --profile production
           cargo deb --profile production
+          target/${{ matrix.job.target }}/production/${{ matrix.job.artifact_name }}
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
+        env:
+          CARGO_TARGET_DIR=./target
 
       - name: Upload Debian file (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -169,10 +169,6 @@ jobs:
           components: rustfmt,clippy
           toolchain: stable
       - uses: taiki-e/install-action@nextest
-      - name: Build optimized binary
-        env:
-          MACOS_DEPLOYMENT_TARGET: 10.7
-        run: cargo build --profile production --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs
       - name: Install packages (Windows)
         if: matrix.job.os == 'windows-latest'
         uses: crazy-max/ghaction-chocolatey@v1.4.0

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -88,6 +88,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install GH CLI
+        uses: dev-hanz-ops/install-gh-cli-action
+
       - name: Create artifacts directory
         run: mkdir artifacts
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -241,7 +241,7 @@ jobs:
         uses: taiki-e/install-action@v2
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         with:
-          tool: cargo-deb@1.42.2
+          tool: cargo-deb@1.43.0
 
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -248,6 +248,7 @@ jobs:
           zip: windows
           checksum: sha256
           target: ${{ matrix.job.target }}
+          asset: bin/git-diffsitter
 
       - name: Upload binary to release (Windows)
         if: matrix.job.os == 'windows-latest'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -248,7 +248,7 @@ jobs:
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
-          cargo deb
+          cargo deb --profile production
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (x86_64-unknown-linux-gnu)

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -220,7 +220,6 @@ jobs:
           zip: windows
           checksum: sha256
           target: ${{ matrix.job.target }}
-          asset: bin/git-diffsitter
 
       - name: Generate Homebrew file
         if: matrix.job.target == 'x86_64-apple-darwin'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -246,6 +246,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tar: unix
           zip: windows
+          checksum: sha256
           target: ${{ matrix.job.target }}
 
       - name: Upload binary to release (Windows)

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -136,6 +136,15 @@ jobs:
           - os: windows-latest
             artifact_name: diffsitter
             target: aarch64-pc-windows-msvc
+          - os: ubuntu-latest
+            artifact_name: diffsitter
+            target: x86_64-unknown-freebsd
+          - os: ubuntu-latest
+            artifact_name: diffsitter
+            target: powerpc64le-unknown-linux-gnu
+          - os: ubuntu-latest
+            artifact_name: diffsitter
+            target: riscv64gc-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -120,7 +120,7 @@ jobs:
             target: i686-unknown-linux-gnu
           - os: ubuntu-latest
             artifact_name: diffsitter
-            target: arm-unknown-linux-gnueabihf
+            target: arm-unknown-linux-gnueabi
           - os: ubuntu-latest
             artifact_name: diffsitter
             target: aarch64-unknown-linux-gnu
@@ -133,7 +133,7 @@ jobs:
           - os: windows-latest
             artifact_name: diffsitter.exe
             target: x86_64-pc-windows-msvc
-          - os: ubuntu-latest
+          - os: windows-latest
             artifact_name: diffsitter
             target: aarch64-pc-windows-msvc
     steps:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -229,7 +229,9 @@ jobs:
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
-          cargo deb --profile production --target ${{ matrix.job.target }} && cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
+          cargo build --profile production --locked
+          cargo deb --profile production --target ${{ matrix.job.target }} --no-build
+          cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
         env:
           CARGO_TARGET_DIR: "./target"
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
-          cargo build --profile production && cargo deb --profile production && cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
+          cargo deb --profile production --target ${{ matrix.job.target }} && cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
         env:
           CARGO_TARGET_DIR: "./target"
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,6 +13,9 @@ on:
     tags:
       - '*'
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   create-github-release:
     name: Create github release

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -220,23 +220,6 @@ jobs:
           checksum: sha256
           target: ${{ matrix.job.target }}
 
-      - name: Generate Homebrew file
-        if: matrix.job.target == 'x86_64-apple-darwin'
-        shell: bash
-        run: |
-          python deployment/brew_packager.py deployment/macos/homebrew/homebrew_formula.rb.template diffsitter.rb ${{ env.RELEASE_VERSION }} ${{ env.CHECKSUM }}
-
-      - name: Upload Homebrew file to release
-        if: matrix.job.target == 'x86_64-apple-darwin'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_path: diffsitter.rb
-          asset_name: diffsitter.rb
-          asset_content_type: application/octet-stream
-
       - name: Install cargo deb
         uses: taiki-e/install-action@v2
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -240,7 +240,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Install cargo deb
-        uses: taiki-e/install-action@cargo-deb
+        uses: taiki-e/install-action@v2
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         with:
           tool: cargo-deb@1.42.2

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -249,7 +249,6 @@ jobs:
         run: |
           cargo build --profile production
           cargo deb --profile production
-          target/${{ matrix.job.target }}/production/${{ matrix.job.artifact_name }}
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
         env:
           CARGO_TARGET_DIR=./target

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -231,7 +231,7 @@ jobs:
         run: |
           cargo build --profile production --locked
           cargo deb --profile production --target ${{ matrix.job.target }} --no-build
-          cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
+          cp ./target/${{ matrix.job.target }}/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
         env:
           CARGO_TARGET_DIR: "./target"
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -263,13 +263,13 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Generate Homebrew file
-        if: matrix.job.os == 'macos-latest'
+        if: matrix.job.target == 'x86_64-apple-darwin'
         shell: bash
         run: |
           python deployment/brew_packager.py deployment/macos/homebrew/homebrew_formula.rb.template diffsitter.rb ${{ env.RELEASE_VERSION }} ${{ env.CHECKSUM }}
 
       - name: Upload Homebrew file to release
-        if: matrix.job.os == 'macos-latest'
+        if: matrix.job.target == 'x86_64-apple-darwin'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -127,10 +127,15 @@ jobs:
           - os: macOS-latest
             artifact_name: diffsitter
             target: x86_64-apple-darwin
+          - os: macOS-latest
+            artifact_name: diffsitter
+            target: aarch64-apple-darwin
           - os: windows-latest
             artifact_name: diffsitter.exe
             target: x86_64-pc-windows-msvc
-
+          - os: ubuntu-latest
+            artifact_name: diffsitter
+            target: aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -200,34 +200,6 @@ jobs:
           release_version="$(cat ./artifacts/release-version)"
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
 
-      - name: Archive release assets (Windows)
-        id: archive_release_assets_windows
-        if: matrix.job.os == 'windows-latest'
-        run: |
-          cp .\target\${{ matrix.job.target }}\production\${{ matrix.job.artifact_name }} ${{ matrix.job.artifact_name }}
-          cp .\bin\git-diffsitter .\git-diffsitter
-          zip -r diffsitter-${{ matrix.job.target }}.zip ${{ matrix.job.artifact_name }} git-diffsitter
-
-      - name: Archive release assets
-        if: matrix.job.os != 'windows-latest'
-        id: archive_release_assets_unix_like
-        shell: bash
-        run: |
-          mkdir -p diffsitter-${{ matrix.job.target }}
-          cp target/${{ matrix.job.target }}/production/${{ matrix.job.artifact_name }} diffsitter-${{ matrix.job.target }}
-          cp bin/git-diffsitter diffsitter-${{ matrix.job.target }}
-          tar -czvf diffsitter-${{ matrix.job.target }}.tar.gz diffsitter-${{ matrix.job.target }}
-
-      - name: Generate SHA256 checksum for binary
-        if: matrix.job.os != 'windows-latest'
-        id: checksum_archive_unix_like
-        shell: bash
-        run: |
-          sha256sum diffsitter-${{ matrix.job.target }}.tar.gz > diffsitter-${{ matrix.job.target }}.tar.gz.sha256
-          checksum=$(cat diffsitter-${{ matrix.job.target }}.tar.gz.sha256)
-          echo "CHECKSUM=$checksum"
-          echo "CHECKSUM=$checksum" >> $GITHUB_ENV
-
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
@@ -249,29 +221,6 @@ jobs:
           checksum: sha256
           target: ${{ matrix.job.target }}
           asset: bin/git-diffsitter
-
-      - name: Upload binary to release (Windows)
-        if: matrix.job.os == 'windows-latest'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          asset_path: diffsitter-${{ matrix.job.target }}.zip
-          asset_name: diffsitter-${{ matrix.job.target }}.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload SHA256 checksum to release
-        if: matrix.job.os != 'windows-latest'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_path: diffsitter-${{ matrix.job.target }}.tar.gz.sha256
-          asset_name: diffsitter-${{ matrix.job.target }}.tar.gz.sha256
-          asset_content_type: application/octet-stream
 
       - name: Generate Homebrew file
         if: matrix.job.target == 'x86_64-apple-darwin'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -115,35 +115,39 @@ jobs:
           - os: ubuntu-latest
             artifact_name: diffsitter
             target: x86_64-unknown-linux-gnu
-            use-cross: false
           - os: ubuntu-latest
             artifact_name: diffsitter
             target: i686-unknown-linux-gnu
-            use-cross: true
           - os: ubuntu-latest
             artifact_name: diffsitter
             target: arm-unknown-linux-gnueabihf
-            use-cross: true
           - os: ubuntu-latest
             artifact_name: diffsitter
             target: aarch64-unknown-linux-gnu
-            use-cross: true
           - os: macOS-latest
             artifact_name: diffsitter
             target: x86_64-apple-darwin
-            use-cross: false
           - os: windows-latest
             artifact_name: diffsitter.exe
             target: x86_64-pc-windows-msvc
-            use-cross: false
 
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@stable
-        targets: ${{ matrix.job.target }}
+      - if: ${{ matrix.job.os == 'ubuntu-latest' }}
+        name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.job.target }}
+      - if: ${{ matrix.job.os != 'ubuntu-latest' }}
+        name: Install native Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          targets: ${{ matrix.job.target }}
+          components: rustfmt,clippy
+          toolchain: stable
       - uses: taiki-e/install-action@nextest
       - name: Build optimized binary
         env:
@@ -152,7 +156,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: cd-${{steps.toolchain.outputs.name}}
-
       - name: Install packages (Windows)
         if: matrix.job.os == 'windows-latest'
         uses: crazy-max/ghaction-chocolatey@v1.4.0

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -292,11 +292,10 @@ jobs:
 
       - name: Build Debian release (x86_64-unknown-linux-gnu)
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
-      - uses: taiki-e/install-action@cargo-deb
+        uses: taiki-e/install-action@cargo-deb
         with:
           tool: cargo-deb@1.42.2
         run: |
-          cargo install cargo-deb --version 1.42.2
           cargo deb
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -239,11 +239,14 @@ jobs:
           asset_name: diffsitter.rb
           asset_content_type: application/octet-stream
 
-      - name: Build Debian release (x86_64-unknown-linux-gnu)
-        if: matrix.job.target == 'x86_64-unknown-linux-gnu'
+      - name: Install cargo deb
         uses: taiki-e/install-action@cargo-deb
+        if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         with:
           tool: cargo-deb@1.42.2
+
+      - name: Build Debian release (x86_64-unknown-linux-gnu)
+        if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
           cargo deb
           cp ./target/debian/diffsitter_*.deb ./diffsitter_${{ env.RELEASE_VERSION }}_amd64.deb

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,12 +45,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - if: ${{ matrix.job.os }} == 'ubuntu-latest'
+      - if: ${{ matrix.job.os == 'ubuntu-latest' }}
         name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.job.target }}
-      - if: ${{ matrix.job.os }} != 'ubuntu-latest'
+      - if: ${{ matrix.job.os != 'ubuntu-latest' }}
         name: Install native Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
             }
           - {
               os: ubuntu-latest,
-              target: arm-unknown-linux-gnueabihf,
+              target: arm7-unknown-linux-gnueabihf,
               use-cross: true,
             }
           - {
@@ -40,6 +40,11 @@ jobs:
           - {
               os: windows-latest,
               target: x86_64-pc-windows-msvc,
+              use-cross: false,
+            }
+          - {
+              os: windows-latest,
+              target: aarch64-pc-windows-msvc,
               use-cross: false,
             }
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-${{steps.toolchain.outputs.name}}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Doc tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,10 +33,6 @@ jobs:
               os: windows-latest,
               target: x86_64-pc-windows-msvc,
             }
-          - {
-              os: windows-latest,
-              target: aarch64-pc-windows-msvc,
-            }
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,17 +55,9 @@ jobs:
           key: ci-${{steps.toolchain.outputs.name}}
       - name: Check formatting
         run: cargo fmt --all -- --check
-        env:
-          CARGO_TERM_COLOR: always
       - name: Build
         run: cargo build --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
-        env:
-          CARGO_TERM_COLOR: always
       - name: Doc tests
         run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
-        env:
-          CARGO_TERM_COLOR: always
       - name: Tests
         run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
-        env:
-          CARGO_TERM_COLOR: always

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,16 +45,17 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Install cross-compilation tools
+      - if: ${{ matrix.job.os }} == 'ubuntu-latest'
+        name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1
-        if: ${{ matrix.job.os }} == 'ubuntu-latest'
         with:
           target: ${{ matrix.job.target }}
-      - name: Install native Rust toolchain
+      - if: ${{ matrix.job.os }} != 'ubuntu-latest'
+        name: Install native Rust toolchain
         uses: dtolnay/rust-toolchain@master
-        if: ${{ matrix.job.os }} != 'ubuntu-latest'
         with:
-          target: ${{ matrix.job.target }}
+          targets: ${{ matrix.job.target }}
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-${{steps.toolchain.outputs.name}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,17 +46,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
         with:
-          targets: ${{ matrix.job.target }}
-          components: clippy,rustfmt
+          target: ${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-${{steps.toolchain.outputs.name}}
       - name: Check formatting
         run: cargo fmt --all -- --check
-      - name: Build
-        run: cargo build --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
       - name: Doc tests
         run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
       - name: Tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,3 +75,4 @@ jobs:
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: '**/target/nextest/ci/junit.xml'
+          check_name: diffsitter tests ${{ matrix.job.target }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,10 @@ jobs:
               os: ubuntu-latest,
               target: i686-unknown-linux-gnu,
             }
-          - {
-              os: ubuntu-latest,
-              target: arm7-unknown-linux-gnueabihf,
-            }
+          # - {
+          #     os: ubuntu-latest,
+          #     target: arm7-unknown-linux-gnueabihf,
+          #   }
           - {
               os: ubuntu-latest,
               target: aarch64-unknown-linux-gnu,

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,15 +49,23 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.job.target }}
-      - uses: taiki-e/install-action@nextest
+          components: clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-${{steps.toolchain.outputs.name}}
       - name: Check formatting
         run: cargo fmt --all -- --check
+        env:
+          CARGO_TERM_COLOR: always
       - name: Build
         run: cargo build --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
+        env:
+          CARGO_TERM_COLOR: always
       - name: Doc tests
         run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
+        env:
+          CARGO_TERM_COLOR: always
       - name: Tests
         run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
+        env:
+          CARGO_TERM_COLOR: always

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Build
         run: cargo build --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
       - name: Doc tests
-        uses: dtolnay/rust-toolchain@stable
         run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
       - name: Tests
         run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,8 +65,8 @@ jobs:
           tool: nextest
       - name: Check formatting
         run: cargo fmt --all -- --check
-      - name: Doc tests
-        if: ${{ matrix.job.target == 'x86_64-unknown-linux-gnu' }}
+      - if: ${{ matrix.job.target == 'x86_64-unknown-linux-gnu' }}
+        name: Doc tests
         run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
       - name: Tests
         run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,36 +16,30 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: macos-latest, target: x86_64-apple-darwin, use-cross: false }
+          - { os: macos-latest, target: x86_64-apple-darwin }
           - {
               os: ubuntu-latest,
               target: x86_64-unknown-linux-gnu,
-              use-cross: false,
             }
           - {
               os: ubuntu-latest,
               target: i686-unknown-linux-gnu,
-              use-cross: true,
             }
           - {
               os: ubuntu-latest,
               target: arm7-unknown-linux-gnueabihf,
-              use-cross: true,
             }
           - {
               os: ubuntu-latest,
               target: aarch64-unknown-linux-gnu,
-              use-cross: true,
             }
           - {
               os: windows-latest,
               target: x86_64-pc-windows-msvc,
-              use-cross: false,
             }
           - {
               os: windows-latest,
               target: aarch64-pc-windows-msvc,
-              use-cross: false,
             }
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           targets: ${{ matrix.job.target }}
           components: rustfmt,clippy
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-${{steps.toolchain.outputs.name}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@stable
-        targets: ${{ matrix.job.target }}
+        with:
+          targets: ${{ matrix.job.target }}
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,12 @@ jobs:
           submodules: true
       - name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1
+        if: ${{ matrix.job.os }} == 'ubuntu-latest'
+        with:
+          target: ${{ matrix.job.target }}
+      - name: Install native Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        if: ${{ matrix.job.os }} != 'ubuntu-latest'
         with:
           target: ${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,6 @@ jobs:
               os: ubuntu-latest,
               target: i686-unknown-linux-gnu,
             }
-          # - {
-          #     os: ubuntu-latest,
-          #     target: arm7-unknown-linux-gnueabihf,
-          #   }
           - {
               os: ubuntu-latest,
               target: aarch64-unknown-linux-gnu,

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Doc tests
+        if: ${{ matrix.job.target == 'x86_64-unknown-linux-gnu' }}
         run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
       - name: Tests
         run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,30 +46,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.job.target }}
-          profile: minimal
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
+        targets: ${{ matrix.job.target }}
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.job.target }}
+          key: ci-${{steps.toolchain.outputs.name}}
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          use-cross: ${{ matrix.job.use-cross }}
-          args: --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
-      - name: Unit tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          use-cross: ${{ matrix.job.use-cross }}
-          args: --locked --target ${{ matrix.job.target }} --verbose --features better-build-info,static-grammar-libs,dynamic-grammar-libs
+        run: cargo build --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
+      - name: Doc tests
+        uses: dtolnay/rust-toolchain@stable
+        run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
+      - name: Tests
+        run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,4 +69,9 @@ jobs:
         name: Doc tests
         run: cargo test --doc --features better-build-info,static-grammar-libs,dynamic-grammar-libs
       - name: Tests
-        run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs
+        run: cargo nextest run --locked --target ${{ matrix.job.target }} --features better-build-info,static-grammar-libs,dynamic-grammar-libs --profile ci
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: '**/target/nextest/ci/junit.xml'

--- a/src/neg_idx_vec.rs
+++ b/src/neg_idx_vec.rs
@@ -157,6 +157,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_negative_overflow() {
         let vec = NegIdxVec::<u32>::from(test_vector());
         let idx = (vec.len() as i32) * -2;

--- a/src/neg_idx_vec.rs
+++ b/src/neg_idx_vec.rs
@@ -157,7 +157,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_negative_overflow() {
         let vec = NegIdxVec::<u32>::from(test_vector());
         let idx = (vec.len() as i32) * -2;


### PR DESCRIPTION
This uses cargo nextest and dtolnay's rust toolchain action. The old
`actions-rs` Github actions have been deprecated and unmaintained.
