### PR TITLE
ci: Fix condition if nightly tag doesn't exist

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -52,8 +52,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git fetch origin --all
           gh release delete nightly --yes || true
-          git push origin :nightly
+          # Taken from: https://stackoverflow.com/questions/46366042/how-to-check-if-tag-exists-in-if-else
+          # We don't want to try deleting the remote tag if it doesn't exist
+          # because that will trigger a failure and abort the nightly release
+          # job.
+          if [[ git rev-parse nightly >/dev/null 2>&1 ]]; then
+            git push origin :nightly
+          fi
           git tag -d nightly || true
           git tag nightly
           git push origin nightly


### PR DESCRIPTION
Fixes an error that was ocurring with our nightly releases where the CD
job would fail if the nightly tag doesn't exist on the remote, which
shouldn't be an error.

Fixes #630.
