### PR TITLE
feat: Add dockerfiles for building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+**/*.md
+assets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1.67 as builder
+WORKDIR /usr/src/diffsitter
+COPY . .
+RUN cargo install --path .
+
+FROM debian:bullseye-slim
+# RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/diffsitter /usr/local/bin/diffsitter
+CMD ["diffsitter"]

--- a/README.md
+++ b/README.md
@@ -224,6 +224,18 @@ apk add diffsitter
 Tree-sitter grammars are packaged separately (search for [tree-sitter-\*](https://pkgs.alpinelinux.org/packages?name=tree-sitter-*&arch=x86_64)).
 You can install individual packages you need or the virtual package `tree-sitter-grammars` to install all of them.
 
+### Building with Docker
+
+We also provide a Docker image that builds diffsitter using the standard Rust
+base image. It separates the compilation stage from the run stage, so you can
+build it and run with the following command (assuming you have Docker installed
+on your system):
+
+```sh
+docker build -t diffsitter .
+docker run -it --rm --name diffsitter-interactive diffsitter
+```
+
 ## Usage
 
 For detailed help you can run `diffsitter --help` (`diffsitter -h` provides


### PR DESCRIPTION
Add a Dockerfile so users can build diffsitter through Docker and add
quick docs on how to build with Docker.
