### PR TITLE
cd: Update versions of actions

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -179,12 +179,12 @@ jobs:
         run: |
           brew install coreutils
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
       - name: Get release download URL
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: artifacts
           path: artifacts


### PR DESCRIPTION
This fixes some warnings about deprecated node versions and API usage in
these actions.
