### PR TITLE
ci(releases): Fix conditional for nightlies

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -207,7 +207,7 @@ jobs:
       # from there.
       - name: Upload Rust binaries for nightly
         uses: taiki-e/upload-rust-binary-action@v1
-        if: github.event.inputs.tag_name == 'nightly'
+        if: env.VERSION == 'nightly'
         with:
           bin: diffsitter
           archive: $bin-$target
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload Rust binaries for release
         uses: taiki-e/upload-rust-binary-action@v1
-        if: github.event.inputs.tag_name != 'nightly'
+        if: env.VERSION != 'nightly'
         with:
           bin: diffsitter
           archive: $bin-$target


### PR DESCRIPTION
The previous conditional statement was not applying correctly for
nightly jobs, which broke the CD jobs because the upload rust binary
action was not being instructed to use a specific tag.
