### PR TITLE
build: Disable extra warnings, std C11

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -105,6 +105,8 @@ fn compile_grammar(
             .include(include)
             .files(c_sources)
             .warnings(false)
+            .extra_warnings(false)
+            .flag_if_supported("-std=c11")
             .try_compile(output_name)?;
     }
 
@@ -114,6 +116,7 @@ fn compile_grammar(
             .include(include)
             .files(cpp_sources)
             .warnings(false)
+            .extra_warnings(false)
             .flag_if_supported("-std=c++14")
             .try_compile(&format!("{}-cpp-compile-diffsiter", &output_name))?;
     }


### PR DESCRIPTION
* Disable extra warnings (not relevant for us since it's not our source)
* Set the compiler standard to C11. This is just for consistency because
  otherwise compilers may set a standard arbitrarily, which could cause
  issues in rare circumstances.
