### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.8.0
+  rev: v2.11.0
   hooks:
    - id: pretty-format-rust
 - repo: https://github.com/afnanenayet/pre-commit-hooks


### PR DESCRIPTION
There was a failure that might be related to some deprecated libraries
that were removed in Python 3.12. This updates the versions of the
pre-commit hooks to more recent ones to rectify the issue.
