### PR TITLE
build(grammars): Fix build settings for md

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -108,9 +108,9 @@ fn compile_grammar(
         cc::Build::new()
             .include(include)
             .files(c_sources)
+            .flag_if_supported("-std=c11")
             .warnings(false)
             .extra_warnings(false)
-            .flag_if_supported("-std=c11")
             .try_compile(&format!("{}-cc-diffsitter", output_name))?;
     }
 
@@ -119,9 +119,9 @@ fn compile_grammar(
             .cpp(true)
             .include(include)
             .files(cpp_sources)
+            .flag_if_supported("-std=c++17")
             .warnings(false)
             .extra_warnings(false)
-            .flag_if_supported("-std=c++17")
             .try_compile(&format!("{}-cxx-diffsitter", &output_name))?;
     }
 
@@ -335,8 +335,9 @@ fn grammars() -> Vec<GrammarCompileInfo<'static>> {
         },
         GrammarCompileInfo {
             display_name: "markdown",
-            path: PathBuf::from("grammars/tree-sitter-markdown/tree-sitter-markdown"),
-            c_sources: vec!["parser.c", "scanner.c"],
+            path: PathBuf::from("grammars/tree-sitter-markdown"),
+            c_sources: vec!["parser.c"],
+            cpp_sources: vec!["scanner.cc"],
             ..Default::default()
         }, // Add new grammars here...
     ];

--- a/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
@@ -11,7 +11,7 @@ RichHunks(
                         line_index: 5,
                         entries: [
                             Entry {
-                                reference: {Node inline (4, 0) - (5, 14)},
+                                reference: {Node paragraph (4, 0) - (6, 0)},
                                 text: "3",
                                 start_position: Point {
                                     row: 5,
@@ -21,7 +21,7 @@ RichHunks(
                                     row: 5,
                                     column: 14,
                                 },
-                                kind_id: 203,
+                                kind_id: 127,
                             },
                         ],
                     },
@@ -35,7 +35,7 @@ RichHunks(
                         line_index: 6,
                         entries: [
                             Entry {
-                                reference: {Node inline (5, 0) - (6, 14)},
+                                reference: {Node paragraph (5, 0) - (7, 0)},
                                 text: "2",
                                 start_position: Point {
                                     row: 6,
@@ -45,7 +45,7 @@ RichHunks(
                                     row: 6,
                                     column: 14,
                                 },
-                                kind_id: 203,
+                                kind_id: 127,
                             },
                         ],
                     },


### PR DESCRIPTION
The build settings were not valid for the new markdown grammar which
caused tests to fail on another PR. This corrects the configuration.

Also changed the order of some of the warning flags in the CC struct builder
to see if that might cause warnings to actually be suppressed.
