### PR TITLE
fix: Check loaded language ABI

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -462,4 +462,23 @@ mod tests {
 
         assert!(failures.is_empty(), "{:#?}", failures);
     }
+
+    #[cfg(feature = "static-grammar-libs")]
+    #[test]
+    fn test_static_grammar_tree_sitter_abi_compatibility() {
+        for (language_name, language_ctor) in &LANGUAGES {
+            unsafe {
+                let language = language_ctor();
+                let version = language.version();
+                assert!(
+                    version >= MIN_COMPATIBLE_LANGUAGE_VERSION && version <= LANGUAGE_VERSION,
+                    "{} has incompatible ABI version: {}. Min/max ABI version = {} - {}",
+                    language_name,
+                    version,
+                    MIN_COMPATIBLE_LANGUAGE_VERSION,
+                    LANGUAGE_VERSION
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Check that the tree-sitter ABI version reported by the loaded language
is within bounds for the tree-sitter client library that's bundled with
diffsitter. This should give more helpful errors when a user has a
grammar that's built against a tree-sitter version that's not in range.

Previously the program would just segfault which does not make it clear
to users that there is a mismatch between the grammar being loaded and
the library bundled in diffsitter.

This closes #782 