### PR TITLE
fix: Update markdown grammar properly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -335,9 +335,8 @@ fn grammars() -> Vec<GrammarCompileInfo<'static>> {
         },
         GrammarCompileInfo {
             display_name: "markdown",
-            path: PathBuf::from("grammars/tree-sitter-markdown"),
-            c_sources: vec!["parser.c"],
-            cpp_sources: vec!["scanner.cc"],
+            path: PathBuf::from("grammars/tree-sitter-markdown/tree-sitter-markdown"),
+            c_sources: vec!["parser.c", "scanner.c"],
             ..Default::default()
         }, // Add new grammars here...
     ];

--- a/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
@@ -11,7 +11,7 @@ RichHunks(
                         line_index: 5,
                         entries: [
                             Entry {
-                                reference: {Node paragraph (4, 0) - (6, 0)},
+                                reference: {Node inline (4, 0) - (5, 14)},
                                 text: "3",
                                 start_position: Point {
                                     row: 5,
@@ -21,7 +21,7 @@ RichHunks(
                                     row: 5,
                                     column: 14,
                                 },
-                                kind_id: 127,
+                                kind_id: 204,
                             },
                         ],
                     },
@@ -35,7 +35,7 @@ RichHunks(
                         line_index: 6,
                         entries: [
                             Entry {
-                                reference: {Node paragraph (5, 0) - (7, 0)},
+                                reference: {Node inline (5, 0) - (6, 14)},
                                 text: "2",
                                 start_position: Point {
                                     row: 6,
@@ -45,7 +45,7 @@ RichHunks(
                                     row: 6,
                                     column: 14,
                                 },
-                                kind_id: 127,
+                                kind_id: 204,
                             },
                         ],
                     },


### PR DESCRIPTION
Use the correct branch for the markdown grammar and update the build +
tests for the new grammar version.
