### PR TITLE
chore: Update actions versions

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -107,7 +107,7 @@ jobs:
         run: echo "${{ env.VERSION }}" > artifacts/release-version
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts
@@ -185,12 +185,12 @@ jobs:
         run: |
           brew install coreutils
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
       - name: Get release download URL
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts
           path: artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
               target: x86_64-pc-windows-msvc,
             }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - if: ${{ matrix.job.os == 'ubuntu-latest' }}


### PR DESCRIPTION
The versions of actions being used before used versions of node that
have been deprecated in gh actions. This bumps the versions to latest so
they are compatible.
