### PR TITLE
test: Less flaky tests, more succinct output

### DIFF
--- a/tests/snapshots/regression_test__tests__medium_cpp_split_graphemes_false_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__medium_cpp_split_graphemes_false_strip_whitespace_true.snap
@@ -1,238 +1,42 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 12,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (12, 12) - (12, 13)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 12,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 24) - (12, 25)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 24,
-                                },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 24,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 36) - (12, 37)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 36,
-                                },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 36,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 17,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (17, 12) - (17, 13)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 12,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 24) - (17, 25)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 24,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 24,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 36) - (17, 37)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 36,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 36,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 43,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 4,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (43, 7) - (43, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 7,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 44,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 4,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (44, 7) - (44, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 45,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 4,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (45, 7) - (45, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 46,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "std",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 4,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (46, 7) - (46, 9)},
-                                text: "::",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=12, entries=
+[
+    Entry{'i', start=(12, 12), end=(12, 12)}
+    Entry{'i', start=(12, 24), end=(12, 24)}
+    Entry{'i', start=(12, 36), end=(12, 36)}
+]}
+)
+Old(Line={line_index=17, entries=
+[
+    Entry{'j', start=(17, 12), end=(17, 12)}
+    Entry{'j', start=(17, 24), end=(17, 24)}
+    Entry{'j', start=(17, 36), end=(17, 36)}
+]}
+)
+Old(Line={line_index=43, entries=
+[
+    Entry{'std', start=(43, 4), end=(43, 4)}
+    Entry{'::', start=(43, 7), end=(43, 7)}
+]}
+
+Line={line_index=44, entries=
+[
+    Entry{'std', start=(44, 4), end=(44, 4)}
+    Entry{'::', start=(44, 7), end=(44, 7)}
+]}
+
+Line={line_index=45, entries=
+[
+    Entry{'std', start=(45, 4), end=(45, 4)}
+    Entry{'::', start=(45, 7), end=(45, 7)}
+]}
+
+Line={line_index=46, entries=
+[
+    Entry{'std', start=(46, 4), end=(46, 4)}
+    Entry{'::', start=(46, 7), end=(46, 7)}
+]}
 )

--- a/tests/snapshots/regression_test__tests__medium_cpp_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__medium_cpp_split_graphemes_true_strip_whitespace_true.snap
@@ -1,394 +1,54 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 12,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (12, 12) - (12, 13)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 13,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 24) - (12, 25)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 24,
-                                },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 25,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (12, 36) - (12, 37)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 12,
-                                    column: 36,
-                                },
-                                end_position: Point {
-                                    row: 12,
-                                    column: 37,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 17,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (17, 12) - (17, 13)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 13,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 24) - (17, 25)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 24,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 25,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (17, 36) - (17, 37)},
-                                text: "j",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 36,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 37,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 43,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 5,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 6,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (43, 4) - (43, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 7,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (43, 7) - (43, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 8,
-                                },
-                                kind_id: 47,
-                            },
-                            Entry {
-                                reference: {Node :: (43, 7) - (43, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 43,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 43,
-                                    column: 9,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 44,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 5,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 6,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (44, 4) - (44, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (44, 7) - (44, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 8,
-                                },
-                                kind_id: 47,
-                            },
-                            Entry {
-                                reference: {Node :: (44, 7) - (44, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 44,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 44,
-                                    column: 9,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 45,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 5,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 6,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (45, 4) - (45, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (45, 7) - (45, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 8,
-                                },
-                                kind_id: 47,
-                            },
-                            Entry {
-                                reference: {Node :: (45, 7) - (45, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 45,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 45,
-                                    column: 9,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 46,
-                        entries: [
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 5,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 6,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node namespace_identifier (46, 4) - (46, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                kind_id: 530,
-                            },
-                            Entry {
-                                reference: {Node :: (46, 7) - (46, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 8,
-                                },
-                                kind_id: 47,
-                            },
-                            Entry {
-                                reference: {Node :: (46, 7) - (46, 9)},
-                                text: ":",
-                                start_position: Point {
-                                    row: 46,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 46,
-                                    column: 9,
-                                },
-                                kind_id: 47,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=12, entries=
+[
+    Entry{'i', start=(12, 12), end=(12, 13)}
+    Entry{'i', start=(12, 24), end=(12, 25)}
+    Entry{'i', start=(12, 36), end=(12, 37)}
+]}
+)
+Old(Line={line_index=17, entries=
+[
+    Entry{'j', start=(17, 12), end=(17, 13)}
+    Entry{'j', start=(17, 24), end=(17, 25)}
+    Entry{'j', start=(17, 36), end=(17, 37)}
+]}
+)
+Old(Line={line_index=43, entries=
+[
+    Entry{'s', start=(43, 4), end=(43, 5)}
+    Entry{'t', start=(43, 5), end=(43, 6)}
+    Entry{'d', start=(43, 6), end=(43, 7)}
+    Entry{':', start=(43, 7), end=(43, 8)}
+    Entry{':', start=(43, 8), end=(43, 9)}
+]}
+
+Line={line_index=44, entries=
+[
+    Entry{'s', start=(44, 4), end=(44, 5)}
+    Entry{'t', start=(44, 5), end=(44, 6)}
+    Entry{'d', start=(44, 6), end=(44, 7)}
+    Entry{':', start=(44, 7), end=(44, 8)}
+    Entry{':', start=(44, 8), end=(44, 9)}
+]}
+
+Line={line_index=45, entries=
+[
+    Entry{'s', start=(45, 4), end=(45, 5)}
+    Entry{'t', start=(45, 5), end=(45, 6)}
+    Entry{'d', start=(45, 6), end=(45, 7)}
+    Entry{':', start=(45, 7), end=(45, 8)}
+    Entry{':', start=(45, 8), end=(45, 9)}
+]}
+
+Line={line_index=46, entries=
+[
+    Entry{'s', start=(46, 4), end=(46, 5)}
+    Entry{'t', start=(46, 5), end=(46, 6)}
+    Entry{'d', start=(46, 6), end=(46, 7)}
+    Entry{':', start=(46, 7), end=(46, 8)}
+    Entry{':', start=(46, 8), end=(46, 9)}
+]}
 )

--- a/tests/snapshots/regression_test__tests__medium_rust_split_graphemes_false_strip_whitespace_false.snap
+++ b/tests/snapshots/regression_test__tests__medium_rust_split_graphemes_false_strip_whitespace_false.snap
@@ -1,446 +1,90 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 2,
-                        entries: [
-                            Entry {
-                                reference: {Node , (2, 26) - (2, 27)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 2,
-                                    column: 26,
-                                },
-                                end_position: Point {
-                                    row: 2,
-                                    column: 26,
-                                },
-                                kind_id: 81,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 20,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "is_naked_fn",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 17,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (17, 7) - (17, 15)},
-                                text: "is_naked",
-                                start_position: Point {
-                                    row: 17,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 17,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 42,
-                        entries: [
-                            Entry {
-                                reference: {Node , (42, 19) - (42, 20)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 42,
-                                    column: 19,
-                                },
-                                end_position: Point {
-                                    row: 42,
-                                    column: 19,
-                                },
-                                kind_id: 81,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 59,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "bleat",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 53,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "talk",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 61,
-                        entries: [
-                            Entry {
-                                reference: {Node string_content (61, 12) - (61, 34)},
-                                text: "{} beats briefly... {}",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 12,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 55,
-                        entries: [
-                            Entry {
-                                reference: {Node string_content (55, 18) - (55, 41)},
-                                text: "{} pauses briefly... {}",
-                                start_position: Point {
-                                    row: 55,
-                                    column: 18,
-                                },
-                                end_position: Point {
-                                    row: 55,
-                                    column: 18,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 67,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (67, 9) - (67, 11)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node string_content (67, 34) - (67, 39)},
-                                text: "Logan",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 34,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 34,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 61,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 12,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node string_content (61, 40) - (61, 45)},
-                                text: "Dolly",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 40,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 40,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 70,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (70, 1) - (70, 3)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 1,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "bleat",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 4,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 71,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (71, 1) - (71, 3)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 71,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 71,
-                                    column: 1,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 72,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (72, 1) - (72, 3)},
-                                text: "ed",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 1,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "bleat",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 4,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 64,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "talk",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 10,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 65,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 66,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "dolly",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "talk",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 10,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=2, entries=
+[
+    Entry{',', start=(2, 26), end=(2, 26)}
+]}
+)
+New(Line={line_index=20, entries=
+[
+    Entry{'is_naked_fn', start=(20, 4), end=(20, 4)}
+]}
+)
+Old(Line={line_index=17, entries=
+[
+    Entry{'is_naked', start=(17, 7), end=(17, 7)}
+]}
+)
+New(Line={line_index=42, entries=
+[
+    Entry{',', start=(42, 19), end=(42, 19)}
+]}
+)
+New(Line={line_index=59, entries=
+[
+    Entry{'bleat', start=(59, 4), end=(59, 4)}
+]}
+)
+Old(Line={line_index=53, entries=
+[
+    Entry{'talk', start=(53, 7), end=(53, 7)}
+]}
+)
+New(Line={line_index=61, entries=
+[
+    Entry{'{} beats briefly... {}', start=(61, 12), end=(61, 12)}
+]}
+)
+Old(Line={line_index=55, entries=
+[
+    Entry{'{} pauses briefly... {}', start=(55, 18), end=(55, 18)}
+]}
+)
+New(Line={line_index=67, entries=
+[
+    Entry{'ed', start=(67, 9), end=(67, 9)}
+    Entry{'Logan', start=(67, 34), end=(67, 34)}
+]}
+)
+Old(Line={line_index=61, entries=
+[
+    Entry{'dolly', start=(61, 12), end=(61, 12)}
+    Entry{'Dolly', start=(61, 40), end=(61, 40)}
+]}
+)
+New(Line={line_index=70, entries=
+[
+    Entry{'ed', start=(70, 1), end=(70, 1)}
+    Entry{'bleat', start=(70, 4), end=(70, 4)}
+]}
+
+Line={line_index=71, entries=
+[
+    Entry{'ed', start=(71, 1), end=(71, 1)}
+]}
+
+Line={line_index=72, entries=
+[
+    Entry{'ed', start=(72, 1), end=(72, 1)}
+    Entry{'bleat', start=(72, 4), end=(72, 4)}
+]}
+)
+Old(Line={line_index=64, entries=
+[
+    Entry{'dolly', start=(64, 4), end=(64, 4)}
+    Entry{'talk', start=(64, 10), end=(64, 10)}
+]}
+
+Line={line_index=65, entries=
+[
+    Entry{'dolly', start=(65, 4), end=(65, 4)}
+]}
+
+Line={line_index=66, entries=
+[
+    Entry{'dolly', start=(66, 4), end=(66, 4)}
+    Entry{'talk', start=(66, 10), end=(66, 10)}
+]}
 )

--- a/tests/snapshots/regression_test__tests__medium_rust_split_graphemes_true_strip_whitespace_false.snap
+++ b/tests/snapshots/regression_test__tests__medium_rust_split_graphemes_true_strip_whitespace_false.snap
@@ -1,1046 +1,133 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 2,
-                        entries: [
-                            Entry {
-                                reference: {Node , (2, 26) - (2, 27)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 2,
-                                    column: 26,
-                                },
-                                end_position: Point {
-                                    row: 2,
-                                    column: 27,
-                                },
-                                kind_id: 81,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 20,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "_",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 13,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "f",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 14,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (20, 4) - (20, 15)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 20,
-                                    column: 14,
-                                },
-                                end_position: Point {
-                                    row: 20,
-                                    column: 15,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 42,
-                        entries: [
-                            Entry {
-                                reference: {Node , (42, 19) - (42, 20)},
-                                text: ",",
-                                start_position: Point {
-                                    row: 42,
-                                    column: 19,
-                                },
-                                end_position: Point {
-                                    row: 42,
-                                    column: 20,
-                                },
-                                kind_id: 81,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 59,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "b",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 5,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (59, 4) - (59, 9)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 59,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 59,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 53,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 10,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (53, 7) - (53, 11)},
-                                text: "k",
-                                start_position: Point {
-                                    row: 53,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 53,
-                                    column: 11,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 55,
-                        entries: [
-                            Entry {
-                                reference: {Node string_content (55, 18) - (55, 41)},
-                                text: "p",
-                                start_position: Point {
-                                    row: 55,
-                                    column: 21,
-                                },
-                                end_position: Point {
-                                    row: 55,
-                                    column: 22,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (55, 18) - (55, 41)},
-                                text: "u",
-                                start_position: Point {
-                                    row: 55,
-                                    column: 23,
-                                },
-                                end_position: Point {
-                                    row: 55,
-                                    column: 24,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (55, 18) - (55, 41)},
-                                text: "s",
-                                start_position: Point {
-                                    row: 55,
-                                    column: 24,
-                                },
-                                end_position: Point {
-                                    row: 55,
-                                    column: 25,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (55, 18) - (55, 41)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 55,
-                                    column: 25,
-                                },
-                                end_position: Point {
-                                    row: 55,
-                                    column: 26,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 61,
-                        entries: [
-                            Entry {
-                                reference: {Node string_content (61, 12) - (61, 34)},
-                                text: "b",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 15,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 16,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (61, 12) - (61, 34)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 16,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 17,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (61, 12) - (61, 34)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 18,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 19,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 67,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (67, 9) - (67, 11)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 10,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (67, 9) - (67, 11)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 11,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node string_content (67, 34) - (67, 39)},
-                                text: "L",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 34,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 35,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (67, 34) - (67, 39)},
-                                text: "g",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 36,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 37,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (67, 34) - (67, 39)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 37,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 38,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (67, 34) - (67, 39)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 67,
-                                    column: 38,
-                                },
-                                end_position: Point {
-                                    row: 67,
-                                    column: 39,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 61,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 13,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 14,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 14,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 15,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 15,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 16,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (61, 12) - (61, 17)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 16,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 17,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node string_content (61, 40) - (61, 45)},
-                                text: "D",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 40,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 41,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (61, 40) - (61, 45)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 42,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 43,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (61, 40) - (61, 45)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 43,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 44,
-                                },
-                                kind_id: 143,
-                            },
-                            Entry {
-                                reference: {Node string_content (61, 40) - (61, 45)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 61,
-                                    column: 44,
-                                },
-                                end_position: Point {
-                                    row: 61,
-                                    column: 45,
-                                },
-                                kind_id: 143,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 70,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (70, 1) - (70, 3)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 2,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node . (70, 3) - (70, 4)},
-                                text: ".",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 3,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 4,
-                                },
-                                kind_id: 77,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "b",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 5,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 6,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 7,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (70, 4) - (70, 9)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 70,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 70,
-                                    column: 8,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 71,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (71, 1) - (71, 3)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 71,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 71,
-                                    column: 2,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (71, 1) - (71, 3)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 71,
-                                    column: 2,
-                                },
-                                end_position: Point {
-                                    row: 71,
-                                    column: 3,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 72,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (72, 1) - (72, 3)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 2,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node . (72, 3) - (72, 4)},
-                                text: ".",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 3,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 4,
-                                },
-                                kind_id: 77,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "b",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 5,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 6,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 7,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (72, 4) - (72, 9)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 72,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 72,
-                                    column: 8,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 64,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (64, 4) - (64, 9)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node . (64, 9) - (64, 10)},
-                                text: ".",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 10,
-                                },
-                                kind_id: 77,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 12,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 13,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (64, 10) - (64, 14)},
-                                text: "k",
-                                start_position: Point {
-                                    row: 64,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 64,
-                                    column: 14,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 65,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 5,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (65, 4) - (65, 9)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 65,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 65,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 66,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (66, 4) - (66, 9)},
-                                text: "y",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node . (66, 9) - (66, 10)},
-                                text: ".",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 10,
-                                },
-                                kind_id: 77,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 12,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 13,
-                                },
-                                kind_id: 341,
-                            },
-                            Entry {
-                                reference: {Node field_identifier (66, 10) - (66, 14)},
-                                text: "k",
-                                start_position: Point {
-                                    row: 66,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 66,
-                                    column: 14,
-                                },
-                                kind_id: 341,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=2, entries=
+[
+    Entry{',', start=(2, 26), end=(2, 27)}
+]}
+)
+New(Line={line_index=20, entries=
+[
+    Entry{'_', start=(20, 12), end=(20, 13)}
+    Entry{'f', start=(20, 13), end=(20, 14)}
+    Entry{'n', start=(20, 14), end=(20, 15)}
+]}
+)
+New(Line={line_index=42, entries=
+[
+    Entry{',', start=(42, 19), end=(42, 20)}
+]}
+)
+New(Line={line_index=59, entries=
+[
+    Entry{'b', start=(59, 4), end=(59, 5)}
+    Entry{'l', start=(59, 5), end=(59, 6)}
+    Entry{'e', start=(59, 6), end=(59, 7)}
+    Entry{'a', start=(59, 7), end=(59, 8)}
+]}
+)
+Old(Line={line_index=53, entries=
+[
+    Entry{'a', start=(53, 8), end=(53, 9)}
+    Entry{'l', start=(53, 9), end=(53, 10)}
+    Entry{'k', start=(53, 10), end=(53, 11)}
+]}
+)
+Old(Line={line_index=55, entries=
+[
+    Entry{'p', start=(55, 21), end=(55, 22)}
+    Entry{'u', start=(55, 23), end=(55, 24)}
+    Entry{'s', start=(55, 24), end=(55, 25)}
+    Entry{'e', start=(55, 25), end=(55, 26)}
+]}
+)
+New(Line={line_index=61, entries=
+[
+    Entry{'b', start=(61, 15), end=(61, 16)}
+    Entry{'e', start=(61, 16), end=(61, 17)}
+    Entry{'t', start=(61, 18), end=(61, 19)}
+]}
+)
+New(Line={line_index=67, entries=
+[
+    Entry{'e', start=(67, 9), end=(67, 10)}
+    Entry{'d', start=(67, 10), end=(67, 11)}
+    Entry{'L', start=(67, 34), end=(67, 35)}
+    Entry{'g', start=(67, 36), end=(67, 37)}
+    Entry{'a', start=(67, 37), end=(67, 38)}
+    Entry{'n', start=(67, 38), end=(67, 39)}
+]}
+)
+Old(Line={line_index=61, entries=
+[
+    Entry{'d', start=(61, 12), end=(61, 13)}
+    Entry{'o', start=(61, 13), end=(61, 14)}
+    Entry{'l', start=(61, 14), end=(61, 15)}
+    Entry{'l', start=(61, 15), end=(61, 16)}
+    Entry{'y', start=(61, 16), end=(61, 17)}
+    Entry{'D', start=(61, 40), end=(61, 41)}
+    Entry{'l', start=(61, 42), end=(61, 43)}
+    Entry{'l', start=(61, 43), end=(61, 44)}
+    Entry{'y', start=(61, 44), end=(61, 45)}
+]}
+)
+New(Line={line_index=70, entries=
+[
+    Entry{'e', start=(70, 1), end=(70, 2)}
+    Entry{'.', start=(70, 3), end=(70, 4)}
+    Entry{'b', start=(70, 4), end=(70, 5)}
+    Entry{'l', start=(70, 5), end=(70, 6)}
+    Entry{'e', start=(70, 6), end=(70, 7)}
+    Entry{'a', start=(70, 7), end=(70, 8)}
+]}
+
+Line={line_index=71, entries=
+[
+    Entry{'e', start=(71, 1), end=(71, 2)}
+    Entry{'d', start=(71, 2), end=(71, 3)}
+]}
+
+Line={line_index=72, entries=
+[
+    Entry{'e', start=(72, 1), end=(72, 2)}
+    Entry{'.', start=(72, 3), end=(72, 4)}
+    Entry{'b', start=(72, 4), end=(72, 5)}
+    Entry{'l', start=(72, 5), end=(72, 6)}
+    Entry{'e', start=(72, 6), end=(72, 7)}
+    Entry{'a', start=(72, 7), end=(72, 8)}
+]}
+)
+Old(Line={line_index=64, entries=
+[
+    Entry{'o', start=(64, 5), end=(64, 6)}
+    Entry{'l', start=(64, 6), end=(64, 7)}
+    Entry{'l', start=(64, 7), end=(64, 8)}
+    Entry{'y', start=(64, 8), end=(64, 9)}
+    Entry{'.', start=(64, 9), end=(64, 10)}
+    Entry{'a', start=(64, 11), end=(64, 12)}
+    Entry{'l', start=(64, 12), end=(64, 13)}
+    Entry{'k', start=(64, 13), end=(64, 14)}
+]}
+
+Line={line_index=65, entries=
+[
+    Entry{'d', start=(65, 4), end=(65, 5)}
+    Entry{'o', start=(65, 5), end=(65, 6)}
+    Entry{'l', start=(65, 6), end=(65, 7)}
+    Entry{'l', start=(65, 7), end=(65, 8)}
+    Entry{'y', start=(65, 8), end=(65, 9)}
+]}
+
+Line={line_index=66, entries=
+[
+    Entry{'o', start=(66, 5), end=(66, 6)}
+    Entry{'l', start=(66, 6), end=(66, 7)}
+    Entry{'l', start=(66, 7), end=(66, 8)}
+    Entry{'y', start=(66, 8), end=(66, 9)}
+    Entry{'.', start=(66, 9), end=(66, 10)}
+    Entry{'a', start=(66, 11), end=(66, 12)}
+    Entry{'l', start=(66, 12), end=(66, 13)}
+    Entry{'k', start=(66, 13), end=(66, 14)}
+]}
 )

--- a/tests/snapshots/regression_test__tests__short_go_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__short_go_split_graphemes_true_strip_whitespace_true.snap
@@ -1,217 +1,30 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 5,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (5, 1) - (5, 3)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 5,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 5,
-                                    column: 2,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (5, 1) - (5, 3)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 5,
-                                    column: 2,
-                                },
-                                end_position: Point {
-                                    row: 5,
-                                    column: 3,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node ( (5, 3) - (5, 4)},
-                                text: "(",
-                                start_position: Point {
-                                    row: 5,
-                                    column: 3,
-                                },
-                                end_position: Point {
-                                    row: 5,
-                                    column: 4,
-                                },
-                                kind_id: 9,
-                            },
-                            Entry {
-                                reference: {Node ) (5, 4) - (5, 5)},
-                                text: ")",
-                                start_position: Point {
-                                    row: 5,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 5,
-                                    column: 5,
-                                },
-                                kind_id: 10,
-                            },
-                        ],
-                    },
-                    Line {
-                        line_index: 6,
-                        entries: [
-                            Entry {
-                                reference: {Node } (6, 0) - (6, 1)},
-                                text: "}",
-                                start_position: Point {
-                                    row: 6,
-                                    column: 0,
-                                },
-                                end_position: Point {
-                                    row: 6,
-                                    column: 1,
-                                },
-                                kind_id: 24,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 8,
-                        entries: [
-                            Entry {
-                                reference: {Node func (8, 0) - (8, 4)},
-                                text: "f",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 0,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 1,
-                                },
-                                kind_id: 15,
-                            },
-                            Entry {
-                                reference: {Node func (8, 0) - (8, 4)},
-                                text: "u",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 2,
-                                },
-                                kind_id: 15,
-                            },
-                            Entry {
-                                reference: {Node func (8, 0) - (8, 4)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 2,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 3,
-                                },
-                                kind_id: 15,
-                            },
-                            Entry {
-                                reference: {Node func (8, 0) - (8, 4)},
-                                text: "c",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 3,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 4,
-                                },
-                                kind_id: 15,
-                            },
-                            Entry {
-                                reference: {Node identifier (8, 5) - (8, 7)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (8, 5) - (8, 7)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node ( (8, 7) - (8, 8)},
-                                text: "(",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 8,
-                                },
-                                kind_id: 9,
-                            },
-                            Entry {
-                                reference: {Node ) (8, 8) - (8, 9)},
-                                text: ")",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 9,
-                                },
-                                kind_id: 10,
-                            },
-                            Entry {
-                                reference: {Node { (8, 10) - (8, 11)},
-                                text: "{",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 11,
-                                },
-                                kind_id: 23,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=5, entries=
+[
+    Entry{'d', start=(5, 1), end=(5, 2)}
+    Entry{'o', start=(5, 2), end=(5, 3)}
+    Entry{'(', start=(5, 3), end=(5, 4)}
+    Entry{')', start=(5, 4), end=(5, 5)}
+]}
+
+Line={line_index=6, entries=
+[
+    Entry{'}', start=(6, 0), end=(6, 1)}
+]}
+)
+New(Line={line_index=8, entries=
+[
+    Entry{'f', start=(8, 0), end=(8, 1)}
+    Entry{'u', start=(8, 1), end=(8, 2)}
+    Entry{'n', start=(8, 2), end=(8, 3)}
+    Entry{'c', start=(8, 3), end=(8, 4)}
+    Entry{'d', start=(8, 5), end=(8, 6)}
+    Entry{'o', start=(8, 6), end=(8, 7)}
+    Entry{'(', start=(8, 7), end=(8, 8)}
+    Entry{')', start=(8, 8), end=(8, 9)}
+    Entry{'{', start=(8, 10), end=(8, 11)}
+]}
 )

--- a/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
@@ -1,56 +1,14 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 5,
-                        entries: [
-                            Entry {
-                                reference: {Node inline (4, 0) - (5, 14)},
-                                text: "3",
-                                start_position: Point {
-                                    row: 5,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 5,
-                                    column: 14,
-                                },
-                                kind_id: 204,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 6,
-                        entries: [
-                            Entry {
-                                reference: {Node inline (5, 0) - (6, 14)},
-                                text: "2",
-                                start_position: Point {
-                                    row: 6,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 6,
-                                    column: 14,
-                                },
-                                kind_id: 204,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=5, entries=
+[
+    Entry{'3', start=(5, 13), end=(5, 14)}
+]}
+)
+Old(Line={line_index=6, entries=
+[
+    Entry{'2', start=(6, 13), end=(6, 14)}
+]}
 )

--- a/tests/snapshots/regression_test__tests__short_python_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__short_python_split_graphemes_true_strip_whitespace_true.snap
@@ -1,108 +1,18 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 4,
-                        entries: [
-                            Entry {
-                                reference: {Node string_content (1, 7) - (5, 4)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 4,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 4,
-                                    column: 13,
-                                },
-                                kind_id: 231,
-                            },
-                            Entry {
-                                reference: {Node string_content (1, 7) - (5, 4)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 4,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 4,
-                                    column: 14,
-                                },
-                                kind_id: 231,
-                            },
-                            Entry {
-                                reference: {Node string_content (1, 7) - (5, 4)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 4,
-                                    column: 14,
-                                },
-                                end_position: Point {
-                                    row: 4,
-                                    column: 15,
-                                },
-                                kind_id: 231,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 8,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (8, 4) - (8, 5)},
-                                text: "x",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 5,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node = (8, 10) - (8, 11)},
-                                text: "=",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 11,
-                                },
-                                kind_id: 44,
-                            },
-                            Entry {
-                                reference: {Node integer (8, 12) - (8, 13)},
-                                text: "1",
-                                start_position: Point {
-                                    row: 8,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 8,
-                                    column: 13,
-                                },
-                                kind_id: 93,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=4, entries=
+[
+    Entry{'n', start=(4, 12), end=(4, 13)}
+    Entry{'o', start=(4, 13), end=(4, 14)}
+    Entry{'t', start=(4, 14), end=(4, 15)}
+]}
+)
+New(Line={line_index=8, entries=
+[
+    Entry{'x', start=(8, 4), end=(8, 5)}
+    Entry{'=', start=(8, 10), end=(8, 11)}
+    Entry{'1', start=(8, 12), end=(8, 13)}
+]}
 )

--- a/tests/snapshots/regression_test__tests__short_rust_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__short_rust_split_graphemes_true_strip_whitespace_true.snap
@@ -1,414 +1,51 @@
 ---
 source: tests/regression_test.rs
-expression: diff_hunks
+expression: snapshot_string
 ---
-RichHunks(
-    [
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 9,
-                        entries: [
-                            Entry {
-                                reference: {Node } (9, 0) - (9, 1)},
-                                text: "}",
-                                start_position: Point {
-                                    row: 9,
-                                    column: 0,
-                                },
-                                end_position: Point {
-                                    row: 9,
-                                    column: 1,
-                                },
-                                kind_id: 9,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 11,
-                        entries: [
-                            Entry {
-                                reference: {Node fn (11, 0) - (11, 2)},
-                                text: "f",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 0,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 1,
-                                },
-                                kind_id: 94,
-                            },
-                            Entry {
-                                reference: {Node fn (11, 0) - (11, 2)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 1,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 2,
-                                },
-                                kind_id: 94,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "a",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 3,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 4,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 5,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "d",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 6,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 7,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "i",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "o",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 10,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (11, 3) - (11, 11)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 11,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node ( (11, 11) - (11, 12)},
-                                text: "(",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 12,
-                                },
-                                kind_id: 4,
-                            },
-                            Entry {
-                                reference: {Node ) (11, 12) - (11, 13)},
-                                text: ")",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 13,
-                                },
-                                kind_id: 5,
-                            },
-                            Entry {
-                                reference: {Node { (11, 14) - (11, 15)},
-                                text: "{",
-                                start_position: Point {
-                                    row: 11,
-                                    column: 14,
-                                },
-                                end_position: Point {
-                                    row: 11,
-                                    column: 15,
-                                },
-                                kind_id: 8,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 1,
-                        entries: [
-                            Entry {
-                                reference: {Node let (1, 4) - (1, 7)},
-                                text: "l",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 4,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 5,
-                                },
-                                kind_id: 98,
-                            },
-                            Entry {
-                                reference: {Node let (1, 4) - (1, 7)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 5,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 6,
-                                },
-                                kind_id: 98,
-                            },
-                            Entry {
-                                reference: {Node let (1, 4) - (1, 7)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 6,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 7,
-                                },
-                                kind_id: 98,
-                            },
-                            Entry {
-                                reference: {Node identifier (1, 8) - (1, 9)},
-                                text: "x",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node = (1, 10) - (1, 11)},
-                                text: "=",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 11,
-                                },
-                                kind_id: 68,
-                            },
-                            Entry {
-                                reference: {Node integer_literal (1, 12) - (1, 13)},
-                                text: "1",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 12,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 13,
-                                },
-                                kind_id: 123,
-                            },
-                            Entry {
-                                reference: {Node ; (1, 13) - (1, 14)},
-                                text: ";",
-                                start_position: Point {
-                                    row: 1,
-                                    column: 13,
-                                },
-                                end_position: Point {
-                                    row: 1,
-                                    column: 14,
-                                },
-                                kind_id: 2,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        New(
-            Hunk(
-                [
-                    Line {
-                        line_index: 14,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (14, 3) - (14, 10)},
-                                text: "t",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 7,
-                                },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 8,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (14, 3) - (14, 10)},
-                                text: "w",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node ( (14, 10) - (14, 11)},
-                                text: "(",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 10,
-                                },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 11,
-                                },
-                                kind_id: 4,
-                            },
-                            Entry {
-                                reference: {Node ) (14, 11) - (14, 12)},
-                                text: ")",
-                                start_position: Point {
-                                    row: 14,
-                                    column: 11,
-                                },
-                                end_position: Point {
-                                    row: 14,
-                                    column: 12,
-                                },
-                                kind_id: 5,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-        Old(
-            Hunk(
-                [
-                    Line {
-                        line_index: 4,
-                        entries: [
-                            Entry {
-                                reference: {Node identifier (4, 3) - (4, 10)},
-                                text: "n",
-                                start_position: Point {
-                                    row: 4,
-                                    column: 8,
-                                },
-                                end_position: Point {
-                                    row: 4,
-                                    column: 9,
-                                },
-                                kind_id: 1,
-                            },
-                            Entry {
-                                reference: {Node identifier (4, 3) - (4, 10)},
-                                text: "e",
-                                start_position: Point {
-                                    row: 4,
-                                    column: 9,
-                                },
-                                end_position: Point {
-                                    row: 4,
-                                    column: 10,
-                                },
-                                kind_id: 1,
-                            },
-                        ],
-                    },
-                ],
-            ),
-        ),
-    ],
+New(Line={line_index=9, entries=
+[
+    Entry{'}', start=(9, 0), end=(9, 1)}
+]}
+)
+New(Line={line_index=11, entries=
+[
+    Entry{'f', start=(11, 0), end=(11, 1)}
+    Entry{'n', start=(11, 1), end=(11, 2)}
+    Entry{'a', start=(11, 3), end=(11, 4)}
+    Entry{'d', start=(11, 4), end=(11, 5)}
+    Entry{'d', start=(11, 5), end=(11, 6)}
+    Entry{'i', start=(11, 6), end=(11, 7)}
+    Entry{'t', start=(11, 7), end=(11, 8)}
+    Entry{'i', start=(11, 8), end=(11, 9)}
+    Entry{'o', start=(11, 9), end=(11, 10)}
+    Entry{'n', start=(11, 10), end=(11, 11)}
+    Entry{'(', start=(11, 11), end=(11, 12)}
+    Entry{')', start=(11, 12), end=(11, 13)}
+    Entry{'{', start=(11, 14), end=(11, 15)}
+]}
+)
+Old(Line={line_index=1, entries=
+[
+    Entry{'l', start=(1, 4), end=(1, 5)}
+    Entry{'e', start=(1, 5), end=(1, 6)}
+    Entry{'t', start=(1, 6), end=(1, 7)}
+    Entry{'x', start=(1, 8), end=(1, 9)}
+    Entry{'=', start=(1, 10), end=(1, 11)}
+    Entry{'1', start=(1, 12), end=(1, 13)}
+    Entry{';', start=(1, 13), end=(1, 14)}
+]}
+)
+New(Line={line_index=14, entries=
+[
+    Entry{'t', start=(14, 7), end=(14, 8)}
+    Entry{'w', start=(14, 8), end=(14, 9)}
+    Entry{'(', start=(14, 10), end=(14, 11)}
+    Entry{')', start=(14, 11), end=(14, 12)}
+]}
+)
+Old(Line={line_index=4, entries=
+[
+    Entry{'n', start=(4, 8), end=(4, 9)}
+    Entry{'e', start=(4, 9), end=(4, 10)}
+]}
 )


### PR DESCRIPTION
Update the snapshot tests so it uses a custom function to generate a
string from the hunks instead of using the debug output. In the past,
tests have broken frequently because of tree-sitter grammar updates.
Typically because a grammar definition adds a new type, or changes
slighlty, which affects fields like `type_id` which fails the regression
test. This is just noise and it doesn't matter what the type ID is.

These new functions also provide a much more compact view of the data,
so it's easier to review test diffs if tests do break.

Example `insta` output from before:

```
  371       │-        Old(
  372       │-            Hunk(
  373       │-                [
  374       │-                    Line {
  375       │-                        line_index: 4,
  376       │-                        entries: [
  377       │-                            Entry {
  378       │-                                reference: {Node identifier (4, 3) - (4, 10)},
  379       │-                                text: "n",
  380       │-                                start_position: Point {
  381       │-                                    row: 4,
  382       │-                                    column: 8,
  383       │-                                },
  384       │-                                end_position: Point {
  385       │-                                    row: 4,
  386       │-                                    column: 9,
  387       │-                                },
  388       │-                                kind_id: 1,
  389       │-                            },
  390       │-                            Entry {
  391       │-                                reference: {Node identifier (4, 3) - (4, 10)},
  392       │-                                text: "e",
  393       │-                                start_position: Point {
  394       │-                                    row: 4,
  395       │-                                    column: 9,
  396       │-                                },
  397       │-                                end_position: Point {
  398       │-                                    row: 4,
  399       │-                                    column: 10,
  400       │-                                },
  401       │-                                kind_id: 1,
  402       │-                            },
  403       │-                        ],
  404       │-                    },
  405       │-                ],
  406       │-            ),
  407       │-        ),
  408       │-    ],
```

New output with insta:

```
         41 │+Old(Line={line_index=4, entries=
         42 │+[
         43 │+    Entry{'n', start=(4, 8), end=(4, 9)}
         44 │+    Entry{'e', start=(4, 9), end=(4, 10)}
         45 │+]}
```

The only issue is that we will have to be careful and make sure we don't forget to update the formatting functions if we add new fields to the hunk data structs.