### PR TITLE
feat: pseudo leaf node types per language

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,22 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
-  hooks:
-  - id: check-yaml
-    exclude: ^grammars/.*
-  - id: end-of-file-fixer
-    exclude: ^grammars/.*
-  - id: trailing-whitespace
-    exclude: grammars/.*
-- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.12.0
-  hooks:
-   - id: pretty-format-rust
-     exclude: ^grammars/.*|^test_data/.*
-- repo: https://github.com/afnanenayet/pre-commit-hooks
-  rev: v0.1.0
-  hooks:
-  - id: pretty-format-toml-taplo
-  - id: check-toml-schema-taplo
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+        exclude: ^grammars/.*|^test_data/.*
+      - id: end-of-file-fixer
+        exclude: ^grammars/.*|^test_data/.*
+      - id: trailing-whitespace
+        exclude: ^grammars/.*|^test_data/.*
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.12.0
+    hooks:
+      - id: pretty-format-rust
+        exclude: ^grammars/.*|^test_data/.*
+  - repo: https://github.com/afnanenayet/pre-commit-hooks
+    rev: v0.1.0
+    hooks:
+      - id: pretty-format-toml-taplo
+        exclude: ^grammars/.*|^test_data/.*
+      - id: check-toml-schema-taplo
+        exclude: ^grammars/.*|^test_data/.*

--- a/src/bin/diffsitter.rs
+++ b/src/bin/diffsitter.rs
@@ -133,12 +133,16 @@ fn run_diff(args: Args, config: Config) -> Result<()> {
 
     let ast_data_a = generate_ast_vector_data(path_a.clone(), file_type, &config.grammar)?;
     let ast_data_b = generate_ast_vector_data(path_b.clone(), file_type, &config.grammar)?;
-    let diff_vec_a = config
-        .input_processing
-        .process(&ast_data_a.tree, &ast_data_a.text);
-    let diff_vec_b = config
-        .input_processing
-        .process(&ast_data_b.tree, &ast_data_b.text);
+    let diff_vec_a = config.input_processing.process(
+        &ast_data_a.tree,
+        &ast_data_a.text,
+        &ast_data_a.resolved_language,
+    );
+    let diff_vec_b = config.input_processing.process(
+        &ast_data_b.tree,
+        &ast_data_b.text,
+        &ast_data_b.resolved_language,
+    );
 
     let hunks = diff::compute_edit_script(&diff_vec_a, &diff_vec_b)?;
     let params = DisplayData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,11 @@ pub fn generate_ast_vector_data(
     } else {
         info!("Will deduce filetype from file extension");
     };
-    let tree = parse::parse_file(&path, file_type, grammar_config)?;
-    Ok(VectorData { text, tree, path })
+    let (tree, resolved_language) = parse::parse_file(&path, file_type, grammar_config)?;
+    Ok(VectorData {
+        text,
+        tree,
+        path,
+        resolved_language,
+    })
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -437,7 +437,7 @@ pub fn parse_file(
     p: &Path,
     language: Option<&str>,
     config: &GrammarConfig,
-) -> Result<Tree, LoadingError> {
+) -> Result<(Tree, String), LoadingError> {
     // Either use the provided language or infer the language to use with the parser from the file
     // extension
     let resolved_language = match language {
@@ -457,7 +457,7 @@ pub fn parse_file(
     match parser.parse(&text, None) {
         Some(ast) => {
             debug!("Parsed AST");
-            Ok(ast)
+            Ok((ast, resolved_language.to_string()))
         }
         None => Err(LoadingError::TSParseFailure(p.to_owned())),
     }

--- a/test_data/short/markdown/a.md
+++ b/test_data/short/markdown/a.md
@@ -3,5 +3,7 @@
 This is
 a paragraph
 
-This 
+This
 is paragraph 2
+
+# Heading (A)

--- a/test_data/short/markdown/b.md
+++ b/test_data/short/markdown/b.md
@@ -2,5 +2,7 @@
 
 This is a paragraph
 
-This 
+This
 is paragraph 3
+
+# Heading (B)

--- a/tests/regression_test.rs
+++ b/tests/regression_test.rs
@@ -106,8 +106,16 @@ mod tests {
             ..Default::default()
         };
 
-        let diff_vec_a = processor.process(&ast_data_a.tree, &ast_data_a.text);
-        let diff_vec_b = processor.process(&ast_data_b.tree, &ast_data_b.text);
+        let diff_vec_a = processor.process(
+            &ast_data_a.tree,
+            &ast_data_a.text,
+            &ast_data_a.resolved_language,
+        );
+        let diff_vec_b = processor.process(
+            &ast_data_b.tree,
+            &ast_data_b.text,
+            &ast_data_b.resolved_language,
+        );
         let diff_hunks = compute_edit_script(&diff_vec_a, &diff_vec_b).unwrap();
 
         // We have to set the snapshot name manually, otherwise there appear to be threading issues

--- a/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
+++ b/tests/snapshots/regression_test__tests__short_markdown_split_graphemes_true_strip_whitespace_true.snap
@@ -12,3 +12,13 @@ Old(Line={line_index=6, entries=
     Entry{'2', start=(6, 13), end=(6, 14)}
 ]}
 )
+New(Line={line_index=7, entries=
+[
+    Entry{'B', start=(7, 11), end=(7, 12)}
+]}
+)
+Old(Line={line_index=8, entries=
+[
+    Entry{'A', start=(8, 11), end=(8, 12)}
+]}
+)


### PR DESCRIPTION
* Allows configuring a pseudo leaf type per language
* Fixes issue with markdown diffs
* Cleans up pre-commit to not lint/format test data
* Updates markdown test to cover case where inline nodes weren't being
  diffed properly
