### PR TITLE
Better config handling with figment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
 name = "cargo-emit"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,9 +165,9 @@ checksum = "1582e1c9e755dd6ad6b224dcffb135d199399a4568d454bd89fe515ca8425695"
 
 [[package]]
 name = "cc"
-version = "1.2.28"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -339,6 +360,7 @@ dependencies = [
  "console 0.16.0",
  "directories-next",
  "enum_dispatch",
+ "figment",
  "human-panic",
  "insta",
  "jemallocator",
@@ -471,6 +493,23 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -608,9 +647,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "human-panic"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7"
+checksum = "ac63a746b187e95d51fe16850eb04d1cfef203f6af98e6c405a6f262ad3df00a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -618,7 +657,7 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml",
+ "toml 0.9.2",
  "uuid",
 ]
 
@@ -770,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "insta"
 version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags",
  "libc",
@@ -927,6 +972,16 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1046,6 +1101,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,9 +1259,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.2"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
+checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64",
  "indexmap",
@@ -1249,10 +1350,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.37.5"
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
 ]
@@ -1290,6 +1404,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1385,15 +1508,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1407,6 +1530,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1436,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1452,6 +1581,15 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -1530,23 +1668,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.104",
 ]
 
@@ -1581,6 +1718,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1731,9 +1881,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_writer",
 ]
 
 [[package]]
@@ -1746,6 +1908,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,8 +1924,8 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
 ]
@@ -1766,10 +1937,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
-name = "tree-sitter"
-version = "0.25.6"
+name = "toml_writer"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7b8994f367f16e6fa14b5aebbcb350de5d7cbea82dc5b00ae997dd71680dd2"
 dependencies = [
  "cc",
  "regex",
@@ -1822,6 +1999,15 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicase"
@@ -2217,9 +2403,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,13 +76,14 @@ human-panic = "2.0.2"
 shadow-rs = { version = "1.2.0", optional = true }
 enum_dispatch = "0.3.13"
 lazy_static = { version = "1.5.0", optional = true }
-config = { version = "0.14.0", features = ["toml", "json5"] }
+figment = { version = "0.10", features = ["toml", "json", "env"] }
 
 [dev-dependencies]
 test-case = "3.3.1"
 pretty_assertions = "1.4.1"
 mockall = "0.13.1"
 rstest = "0.25"
+figment = { version = "0.10", features = ["toml", "json", "env", "test"] }
 
 # We need the backtrace feature to enable snapshot name generation in
 # single-threaded tests (tests using cargo cross run single-threaded due to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ human-panic = "2.0.2"
 shadow-rs = { version = "1.2.0", optional = true }
 enum_dispatch = "0.3.13"
 lazy_static = { version = "1.5.0", optional = true }
+config = { version = "0.14.0", features = ["toml", "json5"] }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/build.rs
+++ b/build.rs
@@ -440,5 +440,11 @@ fn main() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
     // TODO(afnan): add generaetd shell completion scripts
+
+    // Needed so tests are rerun if we change/update any of the test input files. Otherwise Cargo
+    // won't know to actually rerun the tests.
+    println!("cargo::rerun-if-changed=resources/test_configs");
+    println!("cargo::rerun-if-changed=assets/sample_config.json5");
+    println!("cargo::rerun-if-env-changed=BASE_TEST_DIR");
     Ok(())
 }

--- a/resources/test_configs/partial_section_1.toml
+++ b/resources/test_configs/partial_section_1.toml
@@ -1,0 +1,3 @@
+[formatting.unified]
+[[addition]]
+regular-foreground = "green"

--- a/resources/test_configs/partial_section_3.json
+++ b/resources/test_configs/partial_section_3.json
@@ -1,0 +1,63 @@
+{
+  "formatting": {
+    "unified": {
+      "addition": {
+        "highlight": null,
+        "emphasized-foreground": {
+          "color256": 0
+        },
+        "bold": true
+      },
+      "deletion": {
+        "regular-foreground": "red",
+        "emphasized-foreground": "red",
+        "bold": true,
+        "underline": false,
+        "prefix": "-"
+      }
+    },
+    "custom": {
+      "custom_render_mode": {
+        "type": "unified",
+        "addition": {
+          "highlight": null,
+          "regular-foreground": "green",
+          "emphasized-foreground": {
+            "color256": 0
+          },
+          "bold": true,
+          "underline": false,
+          "prefix": "+"
+        },
+        "deletion": {
+          "regular-foreground": "red",
+          "emphasized-foreground": "red",
+          "bold": true,
+          "underline": false,
+          "prefix": "-"
+        }
+      }
+    }
+  },
+  "grammar": {
+    "file-associations": {
+      "rs": "rust"
+    },
+    "dylib-overrides": {
+      "rust": "libtree-sitter-rust.so",
+      "c": "/usr/lib/libtree-sitter-c.so",
+      "cpp": "../libtree-sitter-cpp.so"
+    }
+  },
+  "fallback-cmd": "diff",
+  "input-processing": {
+    "split-graphemes": true,
+    "exclude-kinds": [
+      "string"
+    ],
+    "include-kinds": [
+      "method_definition"
+    ],
+    "strip-whitespace": true
+  }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,20 @@
 //! Utilities and definitions for config handling
 
-use crate::input_processing::TreeSitterProcessor;
-use crate::{parse::GrammarConfig, render::RenderConfig};
-use anyhow::{Context, Result};
-use json5 as json;
-use log::info;
+use crate::{
+    cli::Args, figment_utils::JsonProvider, input_processing::TreeSitterProcessor,
+    parse::GrammarConfig, render::RenderConfig,
+};
+use anyhow::Result;
+use figment::{
+    self,
+    providers::{Format, Serialized},
+    Figment,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    fs, io,
+    ffi::OsStr,
+    io,
     path::{Path, PathBuf},
 };
 use thiserror::Error;
@@ -18,6 +24,9 @@ use directories_next::ProjectDirs;
 
 /// The expected filename for the config file
 const CFG_FILE_NAME: &str = "config.json5";
+
+/// The app name used for configuration purposes.
+pub const APP_NAME: &str = "diffsitter";
 
 /// The config struct for the application
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -69,29 +78,95 @@ impl Config {
     /// default config file path is supposed to be (based on OS conventions, see
     /// [`default_config_file_path`]).
     ///
+    /// # Args
+    ///
+    /// * path: An optional path. If `None` is provided, then try to find the default config file
+    ///   path, unless `no_config` is set to true.
+    /// * no_config: Corresponds to the `--no-config` CLI option.
+    ///
     /// # Errors
     ///
     /// This method will return an error if the config cannot be parsed or if no default config
     /// exists.
-    pub fn try_from_file<P: AsRef<Path>>(path: Option<&P>) -> Result<Self, ReadError> {
-        // rustc will emit an incorrect warning that this variable isn't used, which is untrue.
-        // While the variable isn't read *directly*, it is used to store the owned PathBuf from
-        // `default_config_file_path` so we can use the reference to the variable in `config_fp`.
-        #[allow(unused_assignments)]
-        let mut default_config_fp = PathBuf::new();
-
-        let config_fp = if let Some(p) = path {
-            p.as_ref()
-        } else {
-            default_config_fp = default_config_file_path().map_err(|_| ReadError::NoDefault)?;
-            default_config_fp.as_ref()
+    pub fn try_from_file<P: AsRef<Path>>(path: Option<&P>, no_config: bool) -> Result<Self> {
+        let fig: Figment = {
+            let mut fig = figment::Figment::from(Serialized::defaults(Config::default()));
+            if let Some(cfg_path) = get_config_path_from_args(path, no_config) {
+                fig = merge_fig_provider_from_ext(fig, &cfg_path)?;
+            }
+            fig
         };
-        info!("Reading config at {}", config_fp.to_string_lossy());
-        let config_contents = fs::read_to_string(config_fp)?;
-        let config = json::from_str(&config_contents)
-            .with_context(|| format!("Failed to parse config at {}", config_fp.to_string_lossy()))
-            .map_err(ReadError::DeserializationFailure)?;
+        let config: Config = fig.extract()?;
         Ok(config)
+    }
+
+    /// Create a new config, parsed hierarchically.
+    ///
+    /// Config values are pulled from the following sources listed in order of precedence:
+    ///
+    /// - environment variables
+    /// - command line flags
+    /// - config files specified at the command line
+    /// - the hardcoded defaults
+    // TODO: check if we can incorporate clap or add the command line flags somehow
+    pub fn new_from_args(cli_args: &Args) -> Result<Self> {
+        Self::try_from_file(cli_args.config.as_ref(), cli_args.no_config)
+    }
+}
+
+/// Select the file path for the diffsitter config.
+///
+/// This will return `None` if the `--no-config` flag is selected by the user. Otherwise it will
+/// look for the first existing config path found in order of precedence.
+///
+/// The search list for config paths (unless `--no-config` is selected)
+///
+/// * path specified by `--config` at the CLI (if applicable)
+/// * path specified by `DIFFSITTER_CONFIG` environment variable
+/// * default config file path
+fn get_config_path_from_args<P: AsRef<Path>>(
+    supplied_path: Option<&P>,
+    no_config: bool,
+) -> Option<PathBuf> {
+    if no_config {
+        return None;
+    }
+    if let Some(path) = supplied_path {
+        return Some(PathBuf::from(path.as_ref()));
+    }
+    default_config_file_path().ok()
+}
+
+/// Merge the given path's figment data.
+///
+/// This is a helper function that constructs the correct figment provider for a given config path
+/// based on the file's path extension. We can't return the figment provider directly, which would
+/// be nicer, because the provider has to be sized and there's no way to generally handle this.
+///
+/// # Supported extensions
+///
+/// * .json
+/// * .json5
+/// * .toml
+///
+/// # Errors
+///
+/// This will return an error the extension is not one of the known extensions.
+fn merge_fig_provider_from_ext(fig: figment::Figment, path: &Path) -> Result<figment::Figment> {
+    use figment::providers::Toml;
+    let ext = path.extension().map_or_else(
+        || {
+            anyhow::bail!(
+                "Config path {} does not have a valid extension",
+                path.to_string_lossy()
+            )
+        },
+        |x| OsStr::to_str(x).ok_or(anyhow::anyhow!("Could not map to OsStr")),
+    )?;
+    match ext {
+        "json5" | "json" => Ok(fig.merge(JsonProvider::file(path))),
+        "toml" => Ok(fig.merge(Toml::file(path))),
+        _ => Err(anyhow::anyhow!("Unrecognized file extension {ext}")),
     }
 }
 
@@ -99,7 +174,7 @@ impl Config {
 /// $`XDG_CONFIG/.config`, where `$XDG_CONFIG` is `$HOME/.config` by default.
 #[cfg(not(target_os = "windows"))]
 fn default_config_file_path() -> Result<PathBuf> {
-    let xdg_dirs = xdg::BaseDirectories::with_prefix("diffsitter");
+    let xdg_dirs = xdg::BaseDirectories::with_prefix(APP_NAME);
     let file_path = xdg_dirs.place_config_file(CFG_FILE_NAME)?;
     Ok(file_path)
 }
@@ -110,7 +185,7 @@ fn default_config_file_path() -> Result<PathBuf> {
 fn default_config_file_path() -> Result<PathBuf> {
     use anyhow::ensure;
 
-    let proj_dirs = ProjectDirs::from("io", "afnan", "diffsitter");
+    let proj_dirs = ProjectDirs::from("io", "afnan", APP_NAME);
     ensure!(proj_dirs.is_some(), "Was not able to retrieve config path");
     let proj_dirs = proj_dirs.unwrap();
     let mut config_file: PathBuf = proj_dirs.config_dir().into();
@@ -122,8 +197,10 @@ fn default_config_file_path() -> Result<PathBuf> {
 mod tests {
     use super::*;
     use anyhow::Context;
-    use std::{env, fs::read_dir};
+    use rstest::*;
+    use std::env;
 
+    // Tests the sample config that's in the docs
     #[test]
     fn test_sample_config() {
         let repo_root =
@@ -133,36 +210,44 @@ mod tests {
             .iter()
             .collect::<PathBuf>();
         assert!(sample_config_path.exists());
-        Config::try_from_file(Some(sample_config_path).as_ref()).unwrap();
+        Config::try_from_file(Some(sample_config_path).as_ref(), false).unwrap();
     }
 
-    #[test]
-    fn test_configs() {
-        let mut test_config_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-        test_config_dir.push("resources/test_configs");
-        assert!(test_config_dir.is_dir());
+    // NOTE: we have to provide the file paths explicitly in the code, otherwise Rust won't know to
+    // rerun if we add a new test case, for example. This is also the most ergonomic way to
+    // parametrize on each file name so we can easily see which case failed.
+    #[rstest]
+    #[case("empty_dict.json5")]
+    #[case("partial_section_1.json")]
+    #[case("partial_section_2.json")]
+    #[case("partial_section_3.json")]
+    #[case("empty_config.toml")]
+    #[case("partial_section_1.toml")]
+    fn test_config_init(#[case] filename: &str) {
+        let mut config_file_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        config_file_path.push("resources/test_configs");
+        assert!(
+            config_file_path.is_dir(),
+            "test resource directory `{}` was not found",
+            config_file_path.to_string_lossy()
+        );
+        config_file_path.push(filename);
+        assert!(
+            config_file_path.is_file(),
+            "Expected test case file {} doesn't exist",
+            config_file_path.to_string_lossy()
+        );
 
-        for config_file_path in read_dir(test_config_dir).unwrap() {
-            let config_file_path = config_file_path.unwrap().path();
-            let has_correct_ext = if let Some(ext) = config_file_path.extension() {
-                ext == "json5"
-            } else {
-                false
-            };
-            if !config_file_path.is_file() || !has_correct_ext {
-                continue;
-            }
-            // We add the context so if there is an error you'll see the actual deserialization
-            // error from serde and which file it failed on, which makes for a much more
-            // informative error message in the test logs.
-            Config::try_from_file(Some(&config_file_path))
-                .with_context(|| {
-                    format!(
-                        "Parsing file {}",
-                        &config_file_path.file_name().unwrap().to_string_lossy()
-                    )
-                })
-                .unwrap();
-        }
+        // We add the context so if there is an error you'll see the actual deserialization
+        // error from serde and which file it failed on, which makes for a much more
+        // informative error message in the test logs.
+        Config::try_from_file(Some(&config_file_path), false)
+            .with_context(|| {
+                format!(
+                    "Error parsing file: {}",
+                    &config_file_path.file_name().unwrap().to_string_lossy()
+                )
+            })
+            .unwrap();
     }
 }

--- a/src/figment_utils.rs
+++ b/src/figment_utils.rs
@@ -1,0 +1,17 @@
+//! Helpers for using the figment config parsing library
+
+use figment::providers::Format;
+use json5 as json;
+
+/// A figment provider that can parse JSON5.
+pub struct JsonProvider;
+
+impl Format for JsonProvider {
+    type Error = json::Error;
+
+    const NAME: &'static str = "JSON";
+
+    fn from_str<'de, T: serde::de::DeserializeOwned>(string: &'de str) -> Result<T, Self::Error> {
+        json::from_str(string)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cli;
 pub mod config;
 pub mod console_utils;
 pub mod diff;
+mod figment_utils;
 pub mod input_processing;
 pub mod neg_idx_vec;
 pub mod parse;


### PR DESCRIPTION
This uses the `figment` library for config handling so there is a better 
handling of inheritance from the defaults. The issue with Serde is that the 
defaults only apply when an entire field of a struct is missing, and it does not work
for cases where part of a config is specified.

This closes #1101 